### PR TITLE
Configurable consul suffix with datacenter and stage validation, PLAT…

### DIFF
--- a/LocalSettings.php
+++ b/LocalSettings.php
@@ -217,6 +217,12 @@ $wgMemCachedDebug = ! $wgCommandLineMode; // true unless in command line mode
  * Elementary variables.
  */
 require_once "$IP/includes/wikia/VariablesBase.php";
+/**
+ * Override some of the consul url's.
+ */
+if( $wgForceConsulDatacenter ){
+	require_once "$IP/includes/wikia/VariablesDatacenterOverrides.php";
+}
 
 /**
  * Access credentials from private repository.

--- a/LocalSettings.php
+++ b/LocalSettings.php
@@ -42,6 +42,30 @@ if ( empty( $wgWikiaDatacenter ) ) {
  */
 $wgWikiaEnvironment = getenv( 'WIKIA_ENVIRONMENT' );
 
+/**
+ * Force override consul suffix
+ * @var string $wgOverwriteConsulSuffix
+ */
+$wgOverwriteConsulSuffix = getenv( 'WIKIA_OVERWRITE_CONSUL_SUFFIX' );
+if( $wgOverwriteConsulSuffix ){
+	switch($wgWikiaEnvironment){
+		case 'dev':
+			if( $wgWikiaDatacenter != 'sjc' && $wgWikiaDatacenter != 'poz' ){
+				throw new RuntimeException( 'Combination of $wgWikiaEnvironment & $wgWikiaDatacenter not permitted: ' .
+											$wgWikiaEnvironment . '-' . $wgWikiaDatacenter );
+			}
+			break;
+		case 'prod':
+			if( $wgWikiaDatacenter != 'sjc' && $wgWikiaDatacenter != 'res' ){
+				throw new RuntimeException( 'Combination of $wgWikiaEnvironment & $wgWikiaDatacenter not permitted: ' .
+											$wgWikiaEnvironment . '-' . $wgWikiaDatacenter );
+			}
+			break;
+		default:
+			throw new RuntimeException( 'Unknown $wgWikiaEnvironment: ' . $wgWikiaEnvironment );
+	}
+}
+
 // CONFIG_REVISION: remove $wgWikiaDatacenter and $wgWikiaEnvironment from the global scope and only use it to load configuration
 if ( empty( $wgWikiaEnvironment ) ) {
     throw new RuntimeException( 'Environment not configured in WIKIA_ENVIRONMENT env variable.' );

--- a/LocalSettings.php
+++ b/LocalSettings.php
@@ -220,7 +220,7 @@ require_once "$IP/includes/wikia/VariablesBase.php";
 /**
  * Override some of the consul url's.
  */
-if( $wgForceConsulDatacenter ){
+if ( $wgForceConsulDatacenter ) {
 	require_once "$IP/includes/wikia/VariablesDatacenterOverrides.php";
 }
 

--- a/LocalSettings.php
+++ b/LocalSettings.php
@@ -44,27 +44,9 @@ $wgWikiaEnvironment = getenv( 'WIKIA_ENVIRONMENT' );
 
 /**
  * Force override consul suffix
- * @var string $wgOverwriteConsulSuffix
+ * @var string $wgForceConsulDatacenter
  */
-$wgOverwriteConsulSuffix = getenv( 'WIKIA_OVERWRITE_CONSUL_SUFFIX' );
-if( $wgOverwriteConsulSuffix ){
-	switch($wgWikiaEnvironment){
-		case 'dev':
-			if( $wgWikiaDatacenter != 'sjc' && $wgWikiaDatacenter != 'poz' ){
-				throw new RuntimeException( 'Combination of $wgWikiaEnvironment & $wgWikiaDatacenter not permitted: ' .
-											$wgWikiaEnvironment . '-' . $wgWikiaDatacenter );
-			}
-			break;
-		case 'prod':
-			if( $wgWikiaDatacenter != 'sjc' && $wgWikiaDatacenter != 'res' ){
-				throw new RuntimeException( 'Combination of $wgWikiaEnvironment & $wgWikiaDatacenter not permitted: ' .
-											$wgWikiaEnvironment . '-' . $wgWikiaDatacenter );
-			}
-			break;
-		default:
-			throw new RuntimeException( 'Unknown $wgWikiaEnvironment: ' . $wgWikiaEnvironment );
-	}
-}
+$wgForceConsulDatacenter = getenv( 'WIKIA_OVERWRITE_CONSUL_SUFFIX' );
 
 // CONFIG_REVISION: remove $wgWikiaDatacenter and $wgWikiaEnvironment from the global scope and only use it to load configuration
 if ( empty( $wgWikiaEnvironment ) ) {

--- a/LocalSettings.php
+++ b/LocalSettings.php
@@ -46,7 +46,7 @@ $wgWikiaEnvironment = getenv( 'WIKIA_ENVIRONMENT' );
  * Force override consul suffix
  * @var string $wgForceConsulDatacenter
  */
-$wgForceConsulDatacenter = getenv( 'WIKIA_OVERWRITE_CONSUL_SUFFIX' );
+$wgForceConsulDatacenter = getenv( 'WIKIA_FORCE_CONSUL_DATACENTER' );
 
 // CONFIG_REVISION: remove $wgWikiaDatacenter and $wgWikiaEnvironment from the global scope and only use it to load configuration
 if ( empty( $wgWikiaEnvironment ) ) {

--- a/includes/wikia/VariablesBase.php
+++ b/includes/wikia/VariablesBase.php
@@ -5872,13 +5872,6 @@ $wgMemCachedServers = [
 	1 => 'prod.twemproxy.service.consul:31000',
 ];
 
-if($wgForceConsulDatacenter) {
-	$wgMemCachedServers = [
-		0 => $wgWikiaEnvironment . '.twemproxy.service.' . $wgWikiaDatacenter . '.consul:21000',
-		1 => $wgWikiaEnvironment . '.twemproxy.service.' . $wgWikiaDatacenter . '.consul:31000',
-	];
-}
-
 /**
  * Read/write timeout for MemCached server communication, in microseconds.
  * @var int $wgMemCachedTimeout
@@ -6400,12 +6393,6 @@ $wgPoolCounterConf = null;
  */
 $wgPoolCounterServers = [ 'prod.kubernetes-lb-l4.service.consul' ];
 
-if($wgForceConsulDatacenter) {
-	$wgPoolCounterServers = [ $wgWikiaEnvironment . '.kubernetes-lb-l4.service.' .
-							  $wgWikiaDatacenter .
-							  '.consul' ];
-}
-
 /**
  * Whether to emit more detailed debug logs for a PoolWorkArticleView
  * Controlled by $wgPoolWorkArticleViewDebugSampleRatio
@@ -6638,9 +6625,6 @@ $wgQueryPageDefaultLimit = 50;
  * @var string $wgRabbitHost
  */
 $wgRabbitHost = 'prod.rabbit.service.consul';
-if($wgForceConsulDatacenter) {
-	$wgRabbitHost = $wgWikiaEnvironment . '.rabbit.service.' . $wgWikiaDatacenter . '.consul';
-}
 
 /**
  * Port used by the datacenter-local Rabbit cluster.
@@ -7235,12 +7219,6 @@ $wgSessionMemCachedServers = [
 	0 => 'prod.twemproxy.service.consul:31001',
 	1 => 'prod.twemproxy.service.consul:21001',
 ];
-if($wgForceConsulDatacenter) {
-	$wgSessionMemCachedServers = [
-		0 => $wgWikiaEnvironment . '.twemproxy.service.' . $wgWikiaDatacenter . '.consul:31001',
-		1 => $wgWikiaEnvironment . '.twemproxy.service.' . $wgWikiaDatacenter . '.consul:21001',
-	];
-}
 
 /**
  * Override to customise the session name.
@@ -7531,10 +7509,6 @@ $wgSMTP = [
 	'auth'   => false,
 	'IDHost' => ''
 ];
-
-if($wgForceConsulDatacenter) {
-	$wgSMTP['host'] = $wgWikiaEnvironment . '.smtp.service.' . $wgWikiaDatacenter . '.consul';
-}
 
 /**
  * Solr host for Search and ArticleService.

--- a/includes/wikia/VariablesBase.php
+++ b/includes/wikia/VariablesBase.php
@@ -5872,6 +5872,13 @@ $wgMemCachedServers = [
 	1 => 'prod.twemproxy.service.consul:31000',
 ];
 
+if($wgOverwriteConsulSuffix) {
+	$wgMemCachedServers = [
+		0 => $wgWikiaEnvironment . '.twemproxy.service.' . $wgWikiaDatacenter . '.consul:21000',
+		1 => $wgWikiaEnvironment . '.twemproxy.service.' . $wgWikiaDatacenter . '.consul:31000',
+	];
+}
+
 /**
  * Read/write timeout for MemCached server communication, in microseconds.
  * @var int $wgMemCachedTimeout
@@ -6393,6 +6400,10 @@ $wgPoolCounterConf = null;
  */
 $wgPoolCounterServers = [ 'prod.kubernetes-lb-l4.service.consul' ];
 
+if($wgOverwriteConsulSuffix) {
+	$wgPoolCounterServers = [ $wgWikiaEnvironment . '.kubernetes-lb-l4.' . $wgWikiaDatacenter . '.consul' ];
+}
+
 /**
  * Whether to emit more detailed debug logs for a PoolWorkArticleView
  * Controlled by $wgPoolWorkArticleViewDebugSampleRatio
@@ -6625,6 +6636,9 @@ $wgQueryPageDefaultLimit = 50;
  * @var string $wgRabbitHost
  */
 $wgRabbitHost = 'prod.rabbit.service.consul';
+if($wgOverwriteConsulSuffix) {
+	$wgRabbitHost = $wgWikiaEnvironment . '.rabbit.service.' . $wgWikiaDatacenter . '.consul';
+}
 
 /**
  * Port used by the datacenter-local Rabbit cluster.
@@ -7219,6 +7233,12 @@ $wgSessionMemCachedServers = [
 	0 => 'prod.twemproxy.service.consul:31001',
 	1 => 'prod.twemproxy.service.consul:21001',
 ];
+if($wgOverwriteConsulSuffix) {
+	$wgSessionMemCachedServers = [
+		0 => $wgWikiaEnvironment . '.twemproxy.service.' . $wgWikiaDatacenter . '.consul:31001',
+		1 => $wgWikiaEnvironment . '.twemproxy.service.' . $wgWikiaDatacenter . '.consul:21001',
+	];
+}
 
 /**
  * Override to customise the session name.
@@ -7510,6 +7530,10 @@ $wgSMTP = [
 	'IDHost' => ''
 ];
 
+if($wgOverwriteConsulSuffix) {
+	$wgSMTP['host'] = $wgWikiaEnvironment . '.smtp.' . $wgWikiaDatacenter . '.consul';
+}
+
 /**
  * Solr host for Search and ArticleService.
  * @see services/ArticleService.class.php
@@ -7518,6 +7542,10 @@ $wgSMTP = [
  */
 $wgSolrHost = 'prod.search-fulltext.service.consul';
 
+if($wgOverwriteConsulSuffix) {
+	$wgSolrHost = $wgWikiaEnvironment . '.search-fulltext.' . $wgWikiaDatacenter . '.consul';
+}
+
 /**
  * Solr host for key-value storage for ArticleService.
  * @see includes/wikia/services/ArticleService.class.php
@@ -7525,13 +7553,17 @@ $wgSolrHost = 'prod.search-fulltext.service.consul';
  */
 $wgSolrKvHost = 'prod.search-kv.service.consul';
 
+if($wgOverwriteConsulSuffix) {
+	$wgSolrKvHost = $wgWikiaEnvironment . '.search-kv.' . $wgWikiaDatacenter . '.consul';
+}
+
 /**
  * Master Solr server used by multiple components.
  * @see includes/wikia/services/tests/ArticleServiceTest.php
  * @see extensions/3rdparty/LyricWiki
  * @see extensions/wikia/Search
  * @see extensions/wikia/VideoHandlers
- * @var strig $wgSolrMaster
+ * @var string $wgSolrMaster
  */
 $wgSolrMaster = 'prod.search-master.service.sjc.consul';
 

--- a/includes/wikia/VariablesBase.php
+++ b/includes/wikia/VariablesBase.php
@@ -5872,7 +5872,7 @@ $wgMemCachedServers = [
 	1 => 'prod.twemproxy.service.consul:31000',
 ];
 
-if($wgOverwriteConsulSuffix) {
+if($wgForceConsulDatacenter) {
 	$wgMemCachedServers = [
 		0 => $wgWikiaEnvironment . '.twemproxy.service.' . $wgWikiaDatacenter . '.consul:21000',
 		1 => $wgWikiaEnvironment . '.twemproxy.service.' . $wgWikiaDatacenter . '.consul:31000',
@@ -6400,8 +6400,10 @@ $wgPoolCounterConf = null;
  */
 $wgPoolCounterServers = [ 'prod.kubernetes-lb-l4.service.consul' ];
 
-if($wgOverwriteConsulSuffix) {
-	$wgPoolCounterServers = [ $wgWikiaEnvironment . '.kubernetes-lb-l4.' . $wgWikiaDatacenter . '.consul' ];
+if($wgForceConsulDatacenter) {
+	$wgPoolCounterServers = [ $wgWikiaEnvironment . '.kubernetes-lb-l4.service.' .
+							  $wgWikiaDatacenter .
+							  '.consul' ];
 }
 
 /**
@@ -6636,7 +6638,7 @@ $wgQueryPageDefaultLimit = 50;
  * @var string $wgRabbitHost
  */
 $wgRabbitHost = 'prod.rabbit.service.consul';
-if($wgOverwriteConsulSuffix) {
+if($wgForceConsulDatacenter) {
 	$wgRabbitHost = $wgWikiaEnvironment . '.rabbit.service.' . $wgWikiaDatacenter . '.consul';
 }
 
@@ -7233,7 +7235,7 @@ $wgSessionMemCachedServers = [
 	0 => 'prod.twemproxy.service.consul:31001',
 	1 => 'prod.twemproxy.service.consul:21001',
 ];
-if($wgOverwriteConsulSuffix) {
+if($wgForceConsulDatacenter) {
 	$wgSessionMemCachedServers = [
 		0 => $wgWikiaEnvironment . '.twemproxy.service.' . $wgWikiaDatacenter . '.consul:31001',
 		1 => $wgWikiaEnvironment . '.twemproxy.service.' . $wgWikiaDatacenter . '.consul:21001',
@@ -7530,8 +7532,8 @@ $wgSMTP = [
 	'IDHost' => ''
 ];
 
-if($wgOverwriteConsulSuffix) {
-	$wgSMTP['host'] = $wgWikiaEnvironment . '.smtp.' . $wgWikiaDatacenter . '.consul';
+if($wgForceConsulDatacenter) {
+	$wgSMTP['host'] = $wgWikiaEnvironment . '.smtp.service.' . $wgWikiaDatacenter . '.consul';
 }
 
 /**
@@ -7542,9 +7544,6 @@ if($wgOverwriteConsulSuffix) {
  */
 $wgSolrHost = 'prod.search-fulltext.service.consul';
 
-if($wgOverwriteConsulSuffix) {
-	$wgSolrHost = $wgWikiaEnvironment . '.search-fulltext.' . $wgWikiaDatacenter . '.consul';
-}
 
 /**
  * Solr host for key-value storage for ArticleService.
@@ -7553,9 +7552,6 @@ if($wgOverwriteConsulSuffix) {
  */
 $wgSolrKvHost = 'prod.search-kv.service.consul';
 
-if($wgOverwriteConsulSuffix) {
-	$wgSolrKvHost = $wgWikiaEnvironment . '.search-kv.' . $wgWikiaDatacenter . '.consul';
-}
 
 /**
  * Master Solr server used by multiple components.

--- a/includes/wikia/VariablesDatacenterOverrides.php
+++ b/includes/wikia/VariablesDatacenterOverrides.php
@@ -15,5 +15,3 @@ $wgPoolCounterServers = [ $wgWikiaEnvironment . '.kubernetes-lb-l4.service.' . $
 $wgRabbitHost = $wgWikiaEnvironment . '.rabbit.service.' . $wgWikiaDatacenter . '.consul';
 
 $wgSMTP['host'] = $wgWikiaEnvironment . '.smtp.service.' . $wgWikiaDatacenter . '.consul';
-
-

--- a/includes/wikia/VariablesDatacenterOverrides.php
+++ b/includes/wikia/VariablesDatacenterOverrides.php
@@ -1,0 +1,19 @@
+<?php
+//Override variables when forced by $wgForceConsulDatacenter
+$wgMemCachedServers = [
+	0 => $wgWikiaEnvironment . '.twemproxy.service.' . $wgWikiaDatacenter . '.consul:21000',
+	1 => $wgWikiaEnvironment . '.twemproxy.service.' . $wgWikiaDatacenter . '.consul:31000',
+];
+
+$wgSessionMemCachedServers = [
+	0 => $wgWikiaEnvironment . '.twemproxy.service.' . $wgWikiaDatacenter . '.consul:31001',
+	1 => $wgWikiaEnvironment . '.twemproxy.service.' . $wgWikiaDatacenter . '.consul:21001',
+];
+
+$wgPoolCounterServers = [ $wgWikiaEnvironment . '.kubernetes-lb-l4.service.' . $wgWikiaDatacenter . '.consul' ];
+
+$wgRabbitHost = $wgWikiaEnvironment . '.rabbit.service.' . $wgWikiaDatacenter . '.consul';
+
+$wgSMTP['host'] = $wgWikiaEnvironment . '.smtp.service.' . $wgWikiaDatacenter . '.consul';
+
+


### PR DESCRIPTION
Based on WIKIA_OVERWRITE_CONSUL_SUFFIX env it checks what stage and dc is used and validates it. After that It overwrites all service.consul sufficex and stage prefixes to the set values.
You can check by setting WIKIA_OVERWRITE_CONSUL_SUFFIX=true SERVER_DBNAME=abador php $PHP_PARAMS /usr/wikia/source/app/maintenance/wikia/HttpsMigration/migrateCheckUser.php