### PR TITLE
PLATFORM-4057| use git abbrev for docker image tag instead of git rev-parse

### DIFF
--- a/docker/preview/Jenkinsfile
+++ b/docker/preview/Jenkinsfile
@@ -314,21 +314,21 @@ node("docker-daemon") {
       parallel (
         "app": {
           dir("app") {
-            appHash = sh(script: 'git rev-parse --short HEAD', returnStdout: true).trim()
+            appHash = sh(script: 'git describe --always --tags --abbrev=7 HEAD', returnStdout: true).trim()
 
             println("Wikia/app commit: $appHash")
           }
         },
         "config": {
           dir("config") {
-            configHash = sh(script: 'git rev-parse --short HEAD', returnStdout: true).trim()
+            configHash = sh(script: 'git describe --always --tags --abbrev=7 HEAD', returnStdout: true).trim()
 
             println("Wikia/config commit: $configHash")
           }
         }
       )
 
-      imageTag = "$appHash.$configHash"
+      imageTag = "$appHash_$configHash"
 
       println("Image tag: $imageTag")
     }

--- a/docker/prod/Jenkinsfile
+++ b/docker/prod/Jenkinsfile
@@ -212,7 +212,7 @@ node("docker-daemon-big") {
               nextAppTag = createTag(currentAppTag)
             }
 
-            appHash = sh(script: 'git rev-parse --short HEAD', returnStdout: true).trim()
+            appHash = sh(script: 'git describe --always --tags --abbrev=7 HEAD', returnStdout: true).trim()
 
             println("Wikia/app commit: $appHash")
           }
@@ -231,14 +231,14 @@ node("docker-daemon-big") {
               nextConfigTag = createTag(currentConfigTag)
             }
 
-            configHash = sh(script: 'git rev-parse --short HEAD', returnStdout: true).trim()
+            configHash = sh(script: 'git describe --always --tags --abbrev=7 HEAD', returnStdout: true).trim()
 
             println("Wikia/config commit: $configHash")
           }
         }
       )
 
-      imageTag = "$appHash.$configHash"
+      imageTag = "$appHash_$configHash"
 
       println("Image tag: $imageTag")
       println("App Tag: $nextAppTag")


### PR DESCRIPTION
When deploying image to artifactory we check if the image exists
but when somebody deployed given version to dev/sandbox it does and
it has `dev@hash` version embedded into it (since at that time
release tags/branches were not created yet). This causes prod
image to display outdated info (though the hash and code remains correct).

ping: @Wikia/core-platform-team, @macbre, @Wikia/services-team 