### PR TITLE
IW-1970 | Fix redirect resolution in LinkSuggest

### DIFF
--- a/extensions/wikia/LinkSuggest/LinkSuggest.class.php
+++ b/extensions/wikia/LinkSuggest/LinkSuggest.class.php
@@ -256,7 +256,7 @@ class LinkSuggest {
 
 			} else {
 
-				$redirTitleFormatted = self::formatTitle($row->page_namespace, $row->rd_title);
+				$redirTitleFormatted = self::formatTitle( $row->rd_namespace, $row->rd_title );
 
 				// remove any instances of original array's value
 				unset( $results[$row->page_id] );

--- a/extensions/wikia/LinkSuggest/LinkSuggest.class.php
+++ b/extensions/wikia/LinkSuggest/LinkSuggest.class.php
@@ -167,10 +167,10 @@ class LinkSuggest {
 		self::formatResults($db, $res, $query, $redirects, $results, $exactMatchRow, $limit);
 		$sql1Measurement->stop();
 		if (count($namespaces) > 0) {
-			$commaJoinedNamespaces = count($namespaces) > 1 ?  array_shift($namespaces) . ', ' . implode(', ', $namespaces) : $namespaces[0];
+			$commaJoinedNamespaces = count($namespaces) > 1 ?  $db->makeList( $namespaces ) : $db->addQuotes( $namespaces[0] );
 		}
 
-		$pageNamespaceClause = isset($commaJoinedNamespaces) ?  'page_namespace IN (' . $commaJoinedNamespaces . ') AND ' : '';
+		$pageNamespaceClause = isset($commaJoinedNamespaces) ?  'page.page_namespace IN (' . $commaJoinedNamespaces . ') AND ' : '';
 		if( count($results) < $limit ) {
 			/**
 			 * @var string $pageTitlePrefilter this condition is able to use name_title index. It's added only for performance reasons.
@@ -186,18 +186,18 @@ class LinkSuggest {
 			if( mb_strlen( $queryLower ) >= 2 ) {
 				if ( LinkSuggest::containsMultibyteCharacters( $firstChar . $secondChar ) ) {
 					$pageTitlePrefilter = "(
-						( convert(binary convert(page_title using latin1) using utf8) LIKE convert(binary '" . strtoupper( $firstChar ) . strtolower( $secondChar ) . "%' using utf8)) ) OR
-						( convert(binary convert(page_title using latin1) using utf8) LIKE convert(binary '" . strtoupper( $firstChar ) . strtoupper( $secondChar )  . "%' using utf8) ) AND ";
+						( convert(binary convert(page.page_title using latin1) using utf8) LIKE convert(binary '" . strtoupper( $firstChar ) . strtolower( $secondChar ) . "%' using utf8)) ) OR
+						( convert(binary convert(page.page_title using latin1) using utf8) LIKE convert(binary '" . strtoupper( $firstChar ) . strtoupper( $secondChar )  . "%' using utf8) ) AND ";
 				} else {
 					$pageTitlePrefilter = "(
-						( convert(binary convert(page_title using latin1) using utf8) " . $db->buildLike( strtoupper( $firstChar ) . strtolower( $secondChar ) , $db->anyString() ) . " ) OR
-						( convert(binary convert(page_title using latin1) using utf8) " . $db->buildLike( strtoupper( $firstChar ) . strtoupper( $secondChar ) , $db->anyString() ) . " ) ) AND ";
+						( convert(binary convert(page.page_title using latin1) using utf8) " . $db->buildLike( strtoupper( $firstChar ) . strtolower( $secondChar ) , $db->anyString() ) . " ) OR
+						( convert(binary convert(page.page_title using latin1) using utf8) " . $db->buildLike( strtoupper( $firstChar ) . strtoupper( $secondChar ) , $db->anyString() ) . " ) ) AND ";
 				}
 			} else if( mb_strlen($queryLower) >= 1 ) {
 				if ( LinkSuggest::containsMultibyteCharacters( $firstChar ) ) {
-					$pageTitlePrefilter = "( convert(binary convert(page_title using latin1) using utf8) LIKE convert(binary '" . $firstChar . "%' using utf8) ) AND ";
+					$pageTitlePrefilter = "( convert(binary convert(page.page_title using latin1) using utf8) LIKE convert(binary '" . $firstChar . "%' using utf8) ) AND ";
 				} else {
-					$pageTitlePrefilter = "( convert(binary convert(page_title using latin1) using utf8) " . $db->buildLike(strtoupper( $firstChar ) , $db->anyString() ) . " ) AND ";
+					$pageTitlePrefilter = "( convert(binary convert(page.page_title using latin1) using utf8) " . $db->buildLike(strtoupper( $firstChar ) , $db->anyString() ) . " ) AND ";
 				}
 			}
 
@@ -207,20 +207,32 @@ class LinkSuggest {
 				$pageTitleLikeClause = "'{$queryLower}%'";
 			}
 
-			// TODO: use $db->select helper method
-			$sql = "SELECT page_len, page_id, page_title, rd_title, page_namespace, rd_namespace, page_is_redirect
-						FROM page
-						LEFT JOIN redirect ON page_is_redirect = 1 AND page_id = rd_from
-						LEFT JOIN querycache ON qc_title = page_title AND qc_type = 'BrokenRedirects'
-						WHERE  {$pageTitlePrefilter} {$pageNamespaceClause} (convert(binary convert(page_title using latin1) using utf8) LIKE {$pageTitleLikeClause} )
-							AND qc_type IS NULL
-						LIMIT ".($limit * 3); // we fetch 3 times more results to leave out redirects to the same page
-
-			$sql2Measurement = T::start([ __FUNCTION__, "sql-2" ]);
-			$res = $db->query($sql, __METHOD__);
+			$res = $db->select(
+				[ 'page', 'redirect', 'redirect_target' => 'page' ],
+				[
+					'page.page_len AS page_len',
+					'page.page_id AS page_id',
+					'page.page_namespace AS page_namespace',
+					'page.page_title AS page_title',
+					'page.page_is_redirect AS page_is_redirect',
+					'rd_namespace',
+					'rd_title',
+					'redirect_target.page_id AS redirect_target_id'
+				],
+				[
+					"{$pageTitlePrefilter} {$pageNamespaceClause} (convert(binary convert(page.page_title using latin1) using utf8) LIKE {$pageTitleLikeClause} )",
+					'page.page_is_redirect = 0 OR redirect_target.page_id IS NOT NULL',
+				],
+				__METHOD__,
+				// we fetch 3 times more results to leave out redirects to the same page
+				[ 'LIMIT' => $limit * 3 ],
+				[
+					'redirect' => [ 'LEFT JOIN', 'page.page_id = rd_from' ],
+					'redirect_target' => [ 'LEFT JOIN', 'rd_namespace = redirect_target.page_namespace AND rd_title = redirect_target.page_title' ],
+				]
+			);
 
 			self::formatResults($db, $res, $query, $redirects, $results, $exactMatchRow, $limit);
-			$sql2Measurement->stop();
 		}
 
 		if ($exactMatchRow !== null) {
@@ -249,7 +261,7 @@ class LinkSuggest {
 				// remove any instances of original array's value
 				unset( $results[$row->page_id] );
 
-				$results = [ $row->page_id => $redirTitleFormatted ] + $results;
+				$results = [ $row->redirect_target_id => $redirTitleFormatted ] + $results;
 
 				$redirects[$titleFormatted] = $redirTitleFormatted;
 			}
@@ -404,7 +416,7 @@ class LinkSuggest {
 
 				if ( !in_array( $redirTitleFormatted, $results ) ) {
 
-					$results[] = $redirTitleFormatted;
+					$results[$row->redirect_target_id] = $redirTitleFormatted;
 					$redirects[$titleFormatted] = $redirTitleFormatted;
 
 				}

--- a/extensions/wikia/LinkSuggest/LinkSuggest.class.php
+++ b/extensions/wikia/LinkSuggest/LinkSuggest.class.php
@@ -166,11 +166,7 @@ class LinkSuggest {
 
 		self::formatResults($db, $res, $query, $redirects, $results, $exactMatchRow, $limit);
 		$sql1Measurement->stop();
-		if (count($namespaces) > 0) {
-			$commaJoinedNamespaces = count($namespaces) > 1 ?  $db->makeList( $namespaces ) : $db->addQuotes( $namespaces[0] );
-		}
 
-		$pageNamespaceClause = isset($commaJoinedNamespaces) ?  'page.page_namespace IN (' . $commaJoinedNamespaces . ') AND ' : '';
 		if( count($results) < $limit ) {
 			/**
 			 * @var string $pageTitlePrefilter this condition is able to use name_title index. It's added only for performance reasons.
@@ -220,7 +216,8 @@ class LinkSuggest {
 					'redirect_target.page_id AS redirect_target_id'
 				],
 				[
-					"{$pageTitlePrefilter} {$pageNamespaceClause} (convert(binary convert(page.page_title using latin1) using utf8) LIKE {$pageTitleLikeClause} )",
+					'page.page_namespace' => $namespaces,
+					"{$pageTitlePrefilter} (convert(binary convert(page.page_title using latin1) using utf8) LIKE {$pageTitleLikeClause} )",
 					'page.page_is_redirect = 0 OR redirect_target.page_id IS NOT NULL',
 				],
 				__METHOD__,

--- a/extensions/wikia/LinkSuggest/LinkSuggest.class.php
+++ b/extensions/wikia/LinkSuggest/LinkSuggest.class.php
@@ -289,9 +289,6 @@ class LinkSuggest {
 			}
 		}
 
-		// Overwrite canonical title with redirect title for all formats
-		self::replaceResultIfRedirected($results, $redirects);
-
 		$format = $request->getText('format');
 
 		if ( $format == 'json' ) {
@@ -351,27 +348,6 @@ class LinkSuggest {
 
 	static function getEmptyResponse($format) {
 		return $format == 'json' ? json_encode(array('suggestions'=>array(),'redirects'=>array())) : '';
-	}
-
-	/**
-	 *
-	 * Helper function for replacing results if redirections are available
-	 *
-	 * @param Array $results
-	 * @param Array $redirects
-	 *
-	 * @return Array
-	 *
-	 * @author Artur Klajnerok <arturk@wikia-inc.com>
-	 *
-	 */
-
-	static private function replaceResultIfRedirected(&$results, &$redirects) {
-		foreach($results as &$val){
-			if (isset($redirects[$val])) {
-				$val = $redirects[$val];
-			}
-		}
 	}
 
 	/**

--- a/extensions/wikia/LinkSuggest/tests/LinkSuggestIntegrationTest.php
+++ b/extensions/wikia/LinkSuggest/tests/LinkSuggestIntegrationTest.php
@@ -1,0 +1,44 @@
+<?php
+
+/**
+ * @group Integration
+ */
+class LinkSuggestIntegrationTest extends WikiaDatabaseTest {
+
+	const REDIRECT_PAGE = 'Thrawn';
+	const REDIRECT_TARGET_ID  = 2;
+	const REDIRECT_TARGET = "Mitth'raw'nuruodo";
+
+	/** @var FauxRequest $webRequest */
+	private $webRequest;
+
+	protected function setUp() {
+		parent::setUp();
+
+		$this->webRequest = new FauxRequest();
+	}
+
+	public function testShouldResolveTargetArticleIdWhenExactMatchIsRedirect() {
+		$this->webRequest->setVal( 'query', 'thrawn' );
+		$this->webRequest->setVal( 'format', 'json' );
+
+		$out = LinkSuggest::getLinkSuggest( $this->webRequest );
+		$data = json_decode( $out, true );
+
+		$this->assertEquals( self::REDIRECT_TARGET_ID, $data['ids'][self::REDIRECT_TARGET] );
+	}
+
+	public function testShouldResolveTargetArticleIdWhenSomeResultIsRedirect() {
+		$this->webRequest->setVal( 'query', 'thraw' );
+		$this->webRequest->setVal( 'format', 'json' );
+
+		$out = LinkSuggest::getLinkSuggest( $this->webRequest );
+		$data = json_decode( $out, true );
+
+		$this->assertEquals( self::REDIRECT_TARGET_ID, $data['ids'][self::REDIRECT_TARGET] );
+	}
+
+	protected function getDataSet() {
+		return $this->createYamlDataSet( __DIR__ . '/link_suggest.yaml' );
+	}
+}

--- a/extensions/wikia/LinkSuggest/tests/LinkSuggestIntegrationTest.php
+++ b/extensions/wikia/LinkSuggest/tests/LinkSuggestIntegrationTest.php
@@ -5,9 +5,10 @@
  */
 class LinkSuggestIntegrationTest extends WikiaDatabaseTest {
 
-	const REDIRECT_PAGE = 'Thrawn';
 	const REDIRECT_TARGET_ID  = 2;
 	const REDIRECT_TARGET = "Mitth'raw'nuruodo";
+
+	const CROSS_NAMESPACE_REDIRECT_TARGET = 'Project page namespaced';
 
 	/** @var FauxRequest $webRequest */
 	private $webRequest;
@@ -36,6 +37,20 @@ class LinkSuggestIntegrationTest extends WikiaDatabaseTest {
 		$data = json_decode( $out, true );
 
 		$this->assertEquals( self::REDIRECT_TARGET_ID, $data['ids'][self::REDIRECT_TARGET] );
+	}
+
+	public function testShouldResolveExactMatchCrossNamespaceRedirectCorrectly() {
+		global $wgContLang;
+
+		$this->webRequest->setVal( 'query', 'project page' );
+		$this->webRequest->setVal( 'format', 'json' );
+
+		$out = LinkSuggest::getLinkSuggest( $this->webRequest );
+		$data = json_decode( $out, true );
+
+		$expected = $wgContLang->getNsText( NS_PROJECT ) . ':' . self::CROSS_NAMESPACE_REDIRECT_TARGET;
+
+		$this->assertArrayHasKey( $expected, $data['ids'] );
 	}
 
 	protected function getDataSet() {

--- a/extensions/wikia/LinkSuggest/tests/link_suggest.yaml
+++ b/extensions/wikia/LinkSuggest/tests/link_suggest.yaml
@@ -15,7 +15,26 @@ page:
     page_random: 0
     page_latest: 0
     page_len: 0
+  - page_id: 3
+    page_namespace: 0
+    page_title: Project_page
+    page_is_redirect: 1
+    page_restrictions: ''
+    page_random: 0
+    page_latest: 0
+    page_len: 0
+  - page_id: 4
+    page_namespace: 4 # NS_PROJECT
+    page_title: Project_page_namespaced
+    page_is_redirect: 0
+    page_restrictions: ''
+    page_random: 0
+    page_latest: 0
+    page_len: 0
 redirect:
   - rd_from: 1
     rd_namespace: 0
     rd_title: Mitth'raw'nuruodo
+  - rd_from: 3
+    rd_namespace: 4 # NS_PROJECT
+    rd_title: Project_page_namespaced

--- a/extensions/wikia/LinkSuggest/tests/link_suggest.yaml
+++ b/extensions/wikia/LinkSuggest/tests/link_suggest.yaml
@@ -1,0 +1,21 @@
+page:
+  - page_id: 1
+    page_namespace: 0
+    page_title: Thrawn
+    page_is_redirect: 1
+    page_restrictions: ''
+    page_random: 0
+    page_latest: 0
+    page_len: 0
+  - page_id: 2
+    page_namespace: 0
+    page_title: Mitth'raw'nuruodo
+    page_is_redirect: 0
+    page_restrictions: ''
+    page_random: 0
+    page_latest: 0
+    page_len: 0
+redirect:
+  - rd_from: 1
+    rd_namespace: 0
+    rd_title: Mitth'raw'nuruodo


### PR DESCRIPTION
Fix resolution of redirect target article IDs in LinkSuggest that was preventing users from adding redirected pages as article tags in Feeds.

There were 3 issues at play:
* If there was an exact match for the search query and it was a redirect, it would be returned with the title of the redirect target, but the article ID of the redirect page.
* If there were non-exact matches for the search query that were redirects, they would be appended to the results array instead of being indexed by redirect target ID. This caused PHP to assign an array index to them, essentially resulting in a bogus article ID that could point to a different page or no page at all.
* Cross-namespace redirect target exact matches were not formatted properly.

This PR fixes all those and adds an integration test for these cases. As an added bonus, by fetching the redirect target article ID from the `page` table, we can get rid of the highly inefficient `JOIN` on the `querycache` table that was used to filter out broken redirects, since we can now test for the absence of the redirect target article ID as an indicator of whether the redirect is broken or not. Here are SQL explains for comparison:

**Before**
![image](https://user-images.githubusercontent.com/2721291/57363250-0465a180-7181-11e9-9625-3cac5871f8c5.png)

**After**
```
+----+-------------+-----------------+------------+--------+-----------------------------------------------------------+--------------------+---------+---------------------------------------------------------+-------+----------+--------------------------+
| id | select_type | table           | partitions | type   | possible_keys                                             | key                | key_len | ref                                                     | rows  | filtered | Extra                    |
+----+-------------+-----------------+------------+--------+-----------------------------------------------------------+--------------------+---------+---------------------------------------------------------+-------+----------+--------------------------+
|  1 | SIMPLE      | page            | NULL       | ref    | name_title,page_redirect_namespace_len,page_ns_latest_idx | page_ns_latest_idx | 4       | const                                                   | 40964 |   100.00 | Using where              |
|  1 | SIMPLE      | redirect        | NULL       | eq_ref | PRIMARY                                                   | PRIMARY            | 4       | pokemon.page.page_id                                    |     1 |   100.00 | Using where              |
|  1 | SIMPLE      | redirect_target | NULL       | eq_ref | name_title,page_ns_latest_idx                             | name_title         | 261     | pokemon.redirect.rd_namespace,pokemon.redirect.rd_title |     1 |   100.00 | Using where; Using index |
+----+-------------+-----------------+------------+--------+-----------------------------------------------------------+--------------------+---------+---------------------------------------------------------+-------+----------+--------------------------+
```

https://wikia-inc.atlassian.net/browse/IW-1970