### PR TITLE
LORE-519 - Implement ArticleExporter API

### DIFF
--- a/extensions/wikia/ArticleExporter/ArticleExporter.class.php
+++ b/extensions/wikia/ArticleExporter/ArticleExporter.class.php
@@ -1,86 +1,86 @@
 <?php
 /**
-* ArticleExporter methods for getting and processing articles
-*
-* @author Lore team
-* @package ArticleExporter
-*/
+ * ArticleExporter methods for getting and processing articles
+ *
+ * @author Lore team
+ * @package ArticleExporter
+ */
 class ArticleExporter {
-    const SPACE_SEQUENCE_REGEXP = "/\s+/";
+	const SPACE_SEQUENCE_REGEXP = "/\s+/";
 
-    public function build($cityId, $ids) {
-        $articles = [];
-        foreach ( $ids as $id ) {
-            $article = $this->getArticle( $id );
-            $title = $this->loadTitle( $id ); // some items not available through parse api
+	public function build($cityId, $ids) {
+		$articles = [];
+		foreach ( $ids as $id ) {
+			$article = $this->getArticle( $id );
+			$title = $this->loadTitle( $id ); // some items not available through parse api
 
-            if ( $article ) {
-                $articles[$id] = [
-                    'wikiId' => $cityId,
+			if ( $article ) {
+				$articles[$id] = [
+					'wikiId' => $cityId,
 					'lang' => $this->getContentLang(),
-                    'pageId' => $id,
-                    'namespace' => $title->getNamespace(),
-                    'revisionId' => strval( $article['parse']['revid'] ),
-                    'title' => $article['parse']['title'],
-                    'url' => $title->getFullURL(),
-                    'plaintextContent' => $this->getPlaintext( $article['parse']['text']['*'] ),
-                    'categories' => $this->getCategories( $article['parse']['categories'] ),
-                    'linkedPageTitles' => $this->getPageTitles( $article['parse']['links'] ),
-                    'updatedUtc' => $this->getUpdated( $article['parse']['revid'] ),
-                ];
-            }
-        }
+					'pageId' => $id,
+					'namespace' => $title->getNamespace(),
+					'revisionId' => strval( $article['parse']['revid'] ),
+					'title' => $article['parse']['title'],
+					'url' => $title->getFullURL(),
+					'plaintextContent' => $this->getPlaintext( $article['parse']['text']['*'] ),
+					'categories' => $this->getCategories( $article['parse']['categories'] ),
+					'linkedPageTitles' => $this->getPageTitles( $article['parse']['links'] ),
+					'updatedUtc' => $this->getUpdated( $article['parse']['revid'] ),
+				];
+			}
+		}
 
-        return $articles;
-    }
-
-    public function getArticle( $pageId ) {
-        return \ApiService::call(
-            [
-                'pageid' => $pageId,
-                'action' => 'parse',
-                'prop' => 'text|revid|categories|links|displaytitle',
-            ]
-        );
-    }
-
-    public function getContentLang() {
-    	global $wgContLanguageCode;
-    	return $wgContLanguageCode;
+		return $articles;
 	}
 
-    // Return a quick plaintext version of the article content. Ideally we want to pull out things
-    // like "Edit" and the TOC - but for the first version this should get us 99% of the way there
-    public function getPlaintext( $text ) {
-        $text = html_entity_decode( strip_tags( $text ), ENT_COMPAT, 'UTF-8' );
-        $text = preg_replace( self::SPACE_SEQUENCE_REGEXP, ' ', $text );
-
-        return str_replace( [ "&lt;", "&gt;" ], "", $text );
-    }
-
-    public function loadTitle( $id ) {
-    	return Title::newFromID($id);
+	public function getArticle( $pageId ) {
+		return \ApiService::call(
+			[
+				'pageid' => $pageId,
+				'action' => 'parse',
+				'prop' => 'text|revid|categories|links|displaytitle',
+			]
+		);
 	}
 
-    public function getCategories( $rawCategories ) {
-        $categories = [];
-        foreach ( $rawCategories as $category ) {
-            array_push( $categories, $category['*'] );
-        }
-        return $categories;
-    }
+	public function getContentLang() {
+		global $wgContLanguageCode;
+		return $wgContLanguageCode;
+	}
 
-    public function getPageTitles( $links ) {
-        $linkedPageTitles = [];
-        foreach ( $links as $link ) {
-            array_push( $linkedPageTitles, $link['*'] );
-        }
-        return $linkedPageTitles;
-    }
+	// Return a quick plaintext version of the article content. Ideally we want to pull out things
+	// like "Edit" and the TOC - but for the first version this should get us 99% of the way there
+	public function getPlaintext( $text ) {
+		$text = html_entity_decode( strip_tags( $text ), ENT_COMPAT, 'UTF-8' );
+		$text = preg_replace( self::SPACE_SEQUENCE_REGEXP, ' ', $text );
 
-    public function getUpdated( $revid ) {
-        $lastRev = \Revision::newFromId( $revid );
-        $timestamp = empty( $lastRev ) ? '' : $lastRev->getTimestamp();
-        return wfTimestamp( TS_ISO_8601, $timestamp ) ;
-    }
+		return str_replace( [ "&lt;", "&gt;" ], "", $text );
+	}
+
+	public function loadTitle( $id ) {
+		return Title::newFromID($id);
+	}
+
+	public function getCategories( $rawCategories ) {
+		$categories = [];
+		foreach ( $rawCategories as $category ) {
+			array_push( $categories, $category['*'] );
+		}
+		return $categories;
+	}
+
+	public function getPageTitles( $links ) {
+		$linkedPageTitles = [];
+		foreach ( $links as $link ) {
+			array_push( $linkedPageTitles, $link['*'] );
+		}
+		return $linkedPageTitles;
+	}
+
+	public function getUpdated( $revid ) {
+		$lastRev = \Revision::newFromId( $revid );
+		$timestamp = empty( $lastRev ) ? '' : $lastRev->getTimestamp();
+		return wfTimestamp( TS_ISO_8601, $timestamp ) ;
+	}
 }

--- a/extensions/wikia/ArticleExporter/ArticleExporter.class.php
+++ b/extensions/wikia/ArticleExporter/ArticleExporter.class.php
@@ -12,11 +12,12 @@ class ArticleExporter {
         $articles = [];
         foreach ( $ids as $id ) {
             $article = $this->getArticle( $id );
-            $title = Title::newFromID( $id ); // some items not available through parse api
+            $title = $this->loadTitle( $id ); // some items not available through parse api
 
             if ( $article ) {
                 $articles[$id] = [
                     'wikiId' => $cityId,
+					'lang' => $this->getContentLang(),
                     'pageId' => $id,
                     'namespace' => $title->getNamespace(),
                     'revisionId' => strval( $article['parse']['revid'] ),
@@ -43,6 +44,11 @@ class ArticleExporter {
         );
     }
 
+    public function getContentLang() {
+    	global $wgContLanguageCode;
+    	return $wgContLanguageCode;
+	}
+
     // Return a quick plaintext version of the article content. Ideally we want to pull out things
     // like "Edit" and the TOC - but for the first version this should get us 99% of the way there
     public function getPlaintext( $text ) {
@@ -51,6 +57,10 @@ class ArticleExporter {
 
         return str_replace( [ "&lt;", "&gt;" ], "", $text );
     }
+
+    public function loadTitle( $id ) {
+    	return Title::newFromID($id);
+	}
 
     public function getCategories( $rawCategories ) {
         $categories = [];

--- a/extensions/wikia/ArticleExporter/ArticleExporter.class.php
+++ b/extensions/wikia/ArticleExporter/ArticleExporter.class.php
@@ -12,14 +12,16 @@ class ArticleExporter {
         $articles = [];
         foreach ( $ids as $id ) {
             $article = $this->getArticle( $id );
+            $title = Title::newFromID( $id ); // some items not available through parse api
 
             if ( $article ) {
                 $articles[$id] = [
                     'wikiId' => $cityId,
                     'pageId' => $id,
+                    'namespace' => $title->getNamespace(),
                     'revisionId' => strval( $article['parse']['revid'] ),
                     'title' => $article['parse']['title'],
-                    'url' => $this->getPageUrl( $id ),
+                    'url' => $title->getFullURL(),
                     'plaintextContent' => $this->getPlaintext( $article['parse']['text']['*'] ),
                     'categories' => $this->getCategories( $article['parse']['categories'] ),
                     'linkedPageTitles' => $this->getPageTitles( $article['parse']['links'] ),
@@ -48,10 +50,6 @@ class ArticleExporter {
         $text = preg_replace( self::SPACE_SEQUENCE_REGEXP, ' ', $text );
 
         return str_replace( [ "&lt;", "&gt;" ], "", $text );
-    }
-
-    public function getPageUrl( $id ) {
-        return Title::newFromId( $id )->getFullURL();
     }
 
     public function getCategories( $rawCategories ) {

--- a/extensions/wikia/ArticleExporter/ArticleExporter.class.php
+++ b/extensions/wikia/ArticleExporter/ArticleExporter.class.php
@@ -1,0 +1,78 @@
+<?php
+/**
+* ArticleExporter methods for getting and processing articles
+*
+* @author Lore team
+* @package ArticleExporter
+*/
+class ArticleExporter {
+    const SPACE_SEQUENCE_REGEXP = "/\s+/";
+
+    public function build($cityId, $ids) {
+        $articles = [];
+        foreach ( $ids as $id ) {
+            $article = $this->getArticle( $id );
+
+            if ( $article ) {
+                $articles[$id] = [
+                    'wikiId' => $cityId,
+                    'pageId' => $id,
+                    'revisionId' => strval( $article['parse']['revid'] ),
+                    'title' => $article['parse']['title'],
+                    'url' => $this->getPageUrl( $id ),
+                    'plaintextContent' => $this->getPlaintext( $article['parse']['text']['*'] ),
+                    'categories' => $this->getCategories( $article['parse']['categories'] ),
+                    'linkedPageTitles' => $this->getPageTitles( $article['parse']['links'] ),
+                    'updatedUtc' => $this->getUpdated( $article['parse']['revid'] ),
+                ];
+            }
+        }
+
+        return $articles;
+    }
+
+    public function getArticle( $pageId ) {
+        return \ApiService::call(
+            [
+                'pageid' => $pageId,
+                'action' => 'parse',
+                'prop' => 'text|revid|categories|links|displaytitle',
+            ]
+        );
+    }
+
+    // Return a quick plaintext version of the article content. Ideally we want to pull out things
+    // like "Edit" and the TOC - but for the first version this should get us 99% of the way there
+    public function getPlaintext( $text ) {
+        $text = html_entity_decode( strip_tags( $text ), ENT_COMPAT, 'UTF-8' );
+        $text = preg_replace( self::SPACE_SEQUENCE_REGEXP, ' ', $text );
+
+        return str_replace( [ "&lt;", "&gt;" ], "", $text );
+    }
+
+    public function getPageUrl( $id ) {
+        return Title::newFromId( $id )->getFullURL();
+    }
+
+    public function getCategories( $rawCategories ) {
+        $categories = [];
+        foreach ( $rawCategories as $category ) {
+            array_push( $categories, $category['*'] );
+        }
+        return $categories;
+    }
+
+    public function getPageTitles( $links ) {
+        $linkedPageTitles = [];
+        foreach ( $links as $link ) {
+            array_push( $linkedPageTitles, $link['*'] );
+        }
+        return $linkedPageTitles;
+    }
+
+    public function getUpdated( $revid ) {
+        $lastRev = \Revision::newFromId( $revid );
+        $timestamp = empty( $lastRev ) ? '' : $lastRev->getTimestamp();
+        return wfTimestamp( TS_ISO_8601, $timestamp ) ;
+    }
+}

--- a/extensions/wikia/ArticleExporter/ArticleExporter.setup.php
+++ b/extensions/wikia/ArticleExporter/ArticleExporter.setup.php
@@ -1,0 +1,15 @@
+<?php
+/**
+ * Article Exporter Extension
+ *
+ * @author Lore team
+ */
+
+$dir = __DIR__ . '/';
+
+
+/**
+ * Wikia API controllers
+ */
+$wgAutoloadClasses['ArticleExporterApiController'] = $dir . 'ArticleExporterApiController.class.php';
+$wgWikiaApiControllers['ArticleExporterApiController'] = $dir . 'ArticleExporterApiController.class.php';

--- a/extensions/wikia/ArticleExporter/ArticleExporter.setup.php
+++ b/extensions/wikia/ArticleExporter/ArticleExporter.setup.php
@@ -12,4 +12,5 @@ $dir = __DIR__ . '/';
  * Wikia API controllers
  */
 $wgAutoloadClasses['ArticleExporterApiController'] = $dir . 'ArticleExporterApiController.class.php';
+$wgAutoloadClasses['ArticleExporter'] = $dir . 'ArticleExporter.class.php';
 $wgWikiaApiControllers['ArticleExporterApiController'] = $dir . 'ArticleExporterApiController.class.php';

--- a/extensions/wikia/ArticleExporter/ArticleExporterApiController.class.php
+++ b/extensions/wikia/ArticleExporter/ArticleExporterApiController.class.php
@@ -8,13 +8,13 @@
 */
 class ArticleExporterApiController extends WikiaApiController {
 	public function getArticles() {
-        global $wgCityId;
+		global $wgCityId;
 		global $wgRequest;
 
 		$ids = $wgRequest->getArray( 'ids' );
 
 		$exporter = new ArticleExporter();
-        $articles = $exporter->build($wgCityId, $ids);
+		$articles = $exporter->build($wgCityId, $ids);
 
 		$this->response->setFormat( WikiaResponse::FORMAT_JSON );
 		$this->response->setValues( [ 'articles' => $articles ] );

--- a/extensions/wikia/ArticleExporter/ArticleExporterApiController.class.php
+++ b/extensions/wikia/ArticleExporter/ArticleExporterApiController.class.php
@@ -31,10 +31,7 @@ class ArticleExporterApiController extends WikiaApiController {
 					'linkedPageTitles' => $this->getPageTitles( $article['parse']['links'] ),
 					'updatedUtc' => $this->getUpdated( $article['parse']['revid'] ),
 				];
-
-				var_dump( $articles[$id]['plaintextContent'] );
 			}
-
 		}
 
 		$this->response->setFormat( WikiaResponse::FORMAT_JSON );

--- a/extensions/wikia/ArticleExporter/ArticleExporterApiController.class.php
+++ b/extensions/wikia/ArticleExporter/ArticleExporterApiController.class.php
@@ -1,0 +1,88 @@
+<?php
+/**
+* Controller to get article content for the taxonomy content classifier
+*
+* @author Lore team
+* @package ArticleExporter
+* @subpackage Controller
+*/
+class ArticleExporterApiController extends WikiaApiController {
+	const SPACE_SEQUENCE_REGEXP = "/\s+/";
+
+	public function getArticles() {
+		global $wgRequest;
+		global $wgCityId;
+
+		$ids = $wgRequest->getArray( 'ids' );
+
+		$articles = [];
+		foreach ( $ids as $id ) {
+			$article = $this->getArticle( $id );
+
+			if ( $article ) {
+				$articles[$id] = [
+					'wikiId' => $wgCityId,
+					'pageId' => $id,
+					'revisionId' => strval( $article['parse']['revid'] ),
+					'title' => $article['parse']['title'],
+					'url' => $this->getPageUrl( $id ),
+					'plaintextContent' => substr( $this->getPlaintext( $article['parse']['text']['*'] ), 0, 2000 ),
+					'categories' => $this->getCategories( $article['parse']['categories'] ),
+					'linkedPageTitles' => $this->getPageTitles( $article['parse']['links'] ),
+					'updatedUtc' => $this->getUpdated( $article['parse']['revid'] ),
+				];
+
+				var_dump( $articles[$id]['plaintextContent'] );
+			}
+
+		}
+
+		$this->response->setFormat( WikiaResponse::FORMAT_JSON );
+		$this->response->setValues( [ 'articles' => $articles ] );
+	}
+
+	protected function getArticle( $pageId ) {
+		return \ApiService::call(
+			[
+				'pageid' => $pageId,
+				'action' => 'parse',
+				'prop' => 'text|revid|categories|links|displaytitle',
+			]
+		);
+	}
+
+	// Return a quick plaintext version of the article content. Ideally we want to pull out things
+	// like "Edit" and the TOC - but for the first version this should get us 99% of the way there
+	protected function getPlaintext( $text ) {
+		$text = html_entity_decode( strip_tags( $text ), ENT_COMPAT, 'UTF-8' );
+		$text = preg_replace( self::SPACE_SEQUENCE_REGEXP, ' ', $text );
+
+		return str_replace( [ "&lt;", "&gt;" ], "", $text );
+	}
+
+	protected function getPageUrl( $id ) {
+		return Title::newFromId( $id )->getFullURL();
+	}
+
+	protected function getCategories( $rawCategories ) {
+		$categories = [];
+		foreach ( $rawCategories as $category ) {
+			array_push( $categories, $category['*'] );
+		}
+		return $categories;
+	}
+
+	protected function getPageTitles( $links ) {
+		$linkedPageTitles = [];
+		foreach ( $links as $link ) {
+			array_push( $linkedPageTitles, $link['*'] );
+		}
+		return $linkedPageTitles;
+	}
+
+	protected function getUpdated( $revid ) {
+		$lastRev = \Revision::newFromId( $revid );
+		$timestamp = empty( $lastRev ) ? '' : $lastRev->getTimestamp();
+		return wfTimestamp( TS_ISO_8601, $timestamp ) ;
+	}
+}

--- a/extensions/wikia/ArticleExporter/ArticleExporterApiController.class.php
+++ b/extensions/wikia/ArticleExporter/ArticleExporterApiController.class.php
@@ -1,85 +1,22 @@
 <?php
 /**
-* Controller to get article content for the taxonomy content classifier
+* API Controller to get article content for the taxonomy content classifier
 *
 * @author Lore team
 * @package ArticleExporter
 * @subpackage Controller
 */
 class ArticleExporterApiController extends WikiaApiController {
-	const SPACE_SEQUENCE_REGEXP = "/\s+/";
-
 	public function getArticles() {
+        global $wgCityId;
 		global $wgRequest;
-		global $wgCityId;
 
 		$ids = $wgRequest->getArray( 'ids' );
 
-		$articles = [];
-		foreach ( $ids as $id ) {
-			$article = $this->getArticle( $id );
-
-			if ( $article ) {
-				$articles[$id] = [
-					'wikiId' => $wgCityId,
-					'pageId' => $id,
-					'revisionId' => strval( $article['parse']['revid'] ),
-					'title' => $article['parse']['title'],
-					'url' => $this->getPageUrl( $id ),
-					'plaintextContent' => $this->getPlaintext( $article['parse']['text']['*'] ),
-					'categories' => $this->getCategories( $article['parse']['categories'] ),
-					'linkedPageTitles' => $this->getPageTitles( $article['parse']['links'] ),
-					'updatedUtc' => $this->getUpdated( $article['parse']['revid'] ),
-				];
-			}
-		}
+		$exporter = new ArticleExporter();
+        $articles = $exporter->build($wgCityId, $ids);
 
 		$this->response->setFormat( WikiaResponse::FORMAT_JSON );
 		$this->response->setValues( [ 'articles' => $articles ] );
-	}
-
-	protected function getArticle( $pageId ) {
-		return \ApiService::call(
-			[
-				'pageid' => $pageId,
-				'action' => 'parse',
-				'prop' => 'text|revid|categories|links|displaytitle',
-			]
-		);
-	}
-
-	// Return a quick plaintext version of the article content. Ideally we want to pull out things
-	// like "Edit" and the TOC - but for the first version this should get us 99% of the way there
-	protected function getPlaintext( $text ) {
-		$text = html_entity_decode( strip_tags( $text ), ENT_COMPAT, 'UTF-8' );
-		$text = preg_replace( self::SPACE_SEQUENCE_REGEXP, ' ', $text );
-
-		return str_replace( [ "&lt;", "&gt;" ], "", $text );
-	}
-
-	protected function getPageUrl( $id ) {
-		return Title::newFromId( $id )->getFullURL();
-	}
-
-	protected function getCategories( $rawCategories ) {
-		$categories = [];
-		foreach ( $rawCategories as $category ) {
-			array_push( $categories, $category['*'] );
-		}
-		return $categories;
-	}
-
-	protected function getPageTitles( $links ) {
-		$linkedPageTitles = [];
-		foreach ( $links as $link ) {
-			array_push( $linkedPageTitles, $link['*'] );
-		}
-		return $linkedPageTitles;
-	}
-
-	protected function getUpdated( $revid ) {
-		$lastRev = \Revision::newFromId( $revid );
-		$timestamp = empty( $lastRev ) ? '' : $lastRev->getTimestamp();
-		return wfTimestamp( TS_ISO_8601, $timestamp ) ;
 	}
 }

--- a/extensions/wikia/ArticleExporter/ArticleExporterApiController.class.php
+++ b/extensions/wikia/ArticleExporter/ArticleExporterApiController.class.php
@@ -26,7 +26,7 @@ class ArticleExporterApiController extends WikiaApiController {
 					'revisionId' => strval( $article['parse']['revid'] ),
 					'title' => $article['parse']['title'],
 					'url' => $this->getPageUrl( $id ),
-					'plaintextContent' => substr( $this->getPlaintext( $article['parse']['text']['*'] ), 0, 2000 ),
+					'plaintextContent' => $this->getPlaintext( $article['parse']['text']['*'] ),
 					'categories' => $this->getCategories( $article['parse']['categories'] ),
 					'linkedPageTitles' => $this->getPageTitles( $article['parse']['links'] ),
 					'updatedUtc' => $this->getUpdated( $article['parse']['revid'] ),

--- a/extensions/wikia/ArticleExporter/tests/ArticleExporterTest.php
+++ b/extensions/wikia/ArticleExporter/tests/ArticleExporterTest.php
@@ -79,7 +79,7 @@ class ArticleExporterTest extends TestCase {
 		$mockArticleExporter = $this->getMockBuilder('ArticleExporter')
 			->setMethods( [ 'getArticle', 'loadTitle', 'getContentLang' ] )
 			->getMock();
-		$mockArticleExporter->expects($this->atLeastOnce())
+		$mockArticleExporter->expects($this->any())
 			->method('getContentLang')
 			->will($this->returnValue('en'));
 
@@ -90,10 +90,10 @@ class ArticleExporterTest extends TestCase {
 		$mockTitle = $this->getMockBuilder('Title')
 			->setMethods([ 'getFullUrl', 'getNamespace' ])
 			->getMock();
-		$mockTitle->expects($this->once())
+		$mockTitle->expects($this->any())
 			->method('getFullUrl')
-			->will($this->returnValue( 'https://community.fandom/wiki/Jon_Snow' ));
-		$mockTitle->expects($this->once())
+			->will($this->returnValue( $url ));
+		$mockTitle->expects($this->any())
 			->method('getNamespace')
 			->will($this->returnValue(NS_MAIN));
 

--- a/extensions/wikia/ArticleExporter/tests/ArticleExporterTest.php
+++ b/extensions/wikia/ArticleExporter/tests/ArticleExporterTest.php
@@ -22,33 +22,34 @@ class ArticleExporterTest extends TestCase {
 
 	public function testSingleArticle() {
 		$jonSnow = $this->buildMockTitle( 'https://community.fandom/wiki/Jon_Snow' );
-		$articleExplorer = $this->buildMockArticleExplorer();
+		$articleExporter = $this->buildMockArticleExporter();
 
-		$articleExplorer->expects($this->once())
+		$articleExporter->expects($this->once())
 			->method('getArticle')
 			->will($this->returnValue( $this->parseResponse ));
 
-		$articleExplorer->expects($this->once())
+		$articleExporter->expects($this->once())
 			->method('loadTitle')
 			->will($this->returnValue( $jonSnow ));
 
-		$articles = $articleExplorer->build('1', ['1']);
+		$articles = $articleExporter->build('1', ['1']);
 
 		$this->assertEquals(1, sizeof($articles));
 	}
 
 	public function testMultipleArticles() {
-		$mockArticleExporter = $this->buildMockArticleExplorer();
+		$jonSnow = $this->buildMockTitle( 'https://community.fandom/wiki/Jon_Snow' );
+		$articleExporter = $this->buildMockArticleExporter();
 
-		$mockArticleExporter->expects($this->exactly(2))
+		$articleExporter->expects($this->exactly(2))
 			->method('getArticle')
 			->will($this->returnValue( $this->parseResponse ));
 
-		$mockArticleExporter->expects($this->exactly(2))
-			->method('getPageUrl')
-			->will($this->returnValue( 'https://community.fandom/wiki/Jon_Snow' ));
+		$articleExporter->expects($this->exactly(2))
+			->method('loadTitle')
+			->will($this->returnValue($jonSnow));
 
-		$articles = $mockArticleExporter->build('1', ['1', '2']);
+		$articles = $articleExporter->build('1', ['1', '2']);
 
 		$this->assertEquals(2, sizeof($articles));
 	}
@@ -74,7 +75,7 @@ class ArticleExporterTest extends TestCase {
 		$this->assertEquals($expected, $updated);
 	}
 
-	private function buildMockArticleExplorer() {
+	private function buildMockArticleExporter() {
 		$mockArticleExporter = $this->getMockBuilder('ArticleExporter')
 			->setMethods( [ 'getArticle', 'loadTitle', 'getContentLang' ] )
 			->getMock();

--- a/extensions/wikia/ArticleExporter/tests/ArticleExporterTest.php
+++ b/extensions/wikia/ArticleExporter/tests/ArticleExporterTest.php
@@ -1,0 +1,79 @@
+<?php
+use PHPUnit\Framework\TestCase;
+
+class ArticleExporterTest extends TestCase {
+    public $articleExporter;
+    public $parseResponse;
+
+    public function setUp() {
+        parent::setUp();
+        require_once __DIR__ . '/../ArticleExporter.class.php';
+
+        $this->articleExporter = new ArticleExporter();
+        $this->parseResponse = ['parse' => [
+            'title' => 'lorem',
+            'revid' => 123,
+            'text' => ['*' => '<div class=\"lorem\">Lorem ipsum</div>'],
+            'categories' => [['*' => 'Character'], ['*' => 'Cast']],
+            'links' => [['*' => 'Jon Snow'], ['*' => 'Ghost']],
+            'displaytitle' => 'lorem'
+        ]];
+    }
+
+    public function testSingleArticle() {
+        $mockArticleExporter = $this->getMockBuilder('ArticleExporter')
+            ->setMethods( [ 'getArticle', 'getPageUrl' ] )
+            ->getMock();
+
+        $mockArticleExporter->expects($this->once())
+            ->method('getArticle')
+            ->will($this->returnValue( $this->parseResponse ));
+
+        $mockArticleExporter->expects($this->once())
+            ->method('getPageUrl')
+            ->will($this->returnValue( 'https://community.fandom/wiki/Jon_Snow' ));
+
+        $articles = $mockArticleExporter->build('1', ['1']);
+
+        $this->assertEquals(1, sizeof($articles));
+    }
+
+    public function testMultipleArticles() {
+        $mockArticleExporter = $this->getMockBuilder('ArticleExporter')
+            ->setMethods( [ 'getArticle', 'getPageUrl' ] )
+            ->getMock();
+
+        $mockArticleExporter->expects($this->exactly(2))
+            ->method('getArticle')
+            ->will($this->returnValue( $this->parseResponse ));
+
+        $mockArticleExporter->expects($this->exactly(2))
+            ->method('getPageUrl')
+            ->will($this->returnValue( 'https://community.fandom/wiki/Jon_Snow' ));
+
+        $articles = $mockArticleExporter->build('1', ['1', '2']);
+
+        $this->assertEquals(2, sizeof($articles));
+    }
+
+    public function testGetPlaintext() {
+        $plaintext = $this->articleExporter->getPlaintext($this->parseResponse['parse']['text']['*']);
+        $this->assertEquals('Lorem ipsum', $plaintext);
+    }
+
+    public function testGetCategories() {
+        $categories = $this->articleExporter->getCategories($this->parseResponse['parse']['categories']);
+        $this->assertEquals(['Character', 'Cast'], $categories);
+    }
+
+    public function testGetPageTitles() {
+        $titles = $this->articleExporter->getPageTitles($this->parseResponse['parse']['links']);
+        $this->assertEquals(['Jon Snow', 'Ghost'], $titles);
+    }
+
+    public function testGetUpdated() {
+        $updated = $this->articleExporter->getUpdated(0);
+        $expected = wfTimestamp( TS_ISO_8601, 0);
+        $this->assertEquals($expected, $updated);
+    }
+}

--- a/extensions/wikia/ArticleExporter/tests/ArticleExporterTest.php
+++ b/extensions/wikia/ArticleExporter/tests/ArticleExporterTest.php
@@ -2,78 +2,100 @@
 use PHPUnit\Framework\TestCase;
 
 class ArticleExporterTest extends TestCase {
-    public $articleExporter;
-    public $parseResponse;
+	public $articleExporter;
+	public $parseResponse;
 
-    public function setUp() {
-        parent::setUp();
-        require_once __DIR__ . '/../ArticleExporter.class.php';
+	public function setUp() {
+		parent::setUp();
+		require_once __DIR__ . '/../ArticleExporter.class.php';
 
-        $this->articleExporter = new ArticleExporter();
-        $this->parseResponse = ['parse' => [
-            'title' => 'lorem',
-            'revid' => 123,
-            'text' => ['*' => '<div class=\"lorem\">Lorem ipsum</div>'],
-            'categories' => [['*' => 'Character'], ['*' => 'Cast']],
-            'links' => [['*' => 'Jon Snow'], ['*' => 'Ghost']],
-            'displaytitle' => 'lorem'
-        ]];
-    }
+		$this->articleExporter = new ArticleExporter();
+		$this->parseResponse = ['parse' => [
+			'title' => 'lorem',
+			'revid' => 123,
+			'text' => ['*' => '<div class=\"lorem\">Lorem ipsum</div>'],
+			'categories' => [['*' => 'Character'], ['*' => 'Cast']],
+			'links' => [['*' => 'Jon Snow'], ['*' => 'Ghost']],
+			'displaytitle' => 'lorem'
+		]];
+	}
 
-    public function testSingleArticle() {
-        $mockArticleExporter = $this->getMockBuilder('ArticleExporter')
-            ->setMethods( [ 'getArticle', 'getPageUrl' ] )
-            ->getMock();
+	public function testSingleArticle() {
+		$jonSnow = $this->buildMockTitle( 'https://community.fandom/wiki/Jon_Snow' );
+		$articleExplorer = $this->buildMockArticleExplorer();
 
-        $mockArticleExporter->expects($this->once())
-            ->method('getArticle')
-            ->will($this->returnValue( $this->parseResponse ));
+		$articleExplorer->expects($this->once())
+			->method('getArticle')
+			->will($this->returnValue( $this->parseResponse ));
 
-        $mockArticleExporter->expects($this->once())
-            ->method('getPageUrl')
-            ->will($this->returnValue( 'https://community.fandom/wiki/Jon_Snow' ));
+		$articleExplorer->expects($this->once())
+			->method('loadTitle')
+			->will($this->returnValue( $jonSnow ));
 
-        $articles = $mockArticleExporter->build('1', ['1']);
+		$articles = $articleExplorer->build('1', ['1']);
 
-        $this->assertEquals(1, sizeof($articles));
-    }
+		$this->assertEquals(1, sizeof($articles));
+	}
 
-    public function testMultipleArticles() {
-        $mockArticleExporter = $this->getMockBuilder('ArticleExporter')
-            ->setMethods( [ 'getArticle', 'getPageUrl' ] )
-            ->getMock();
+	public function testMultipleArticles() {
+		$mockArticleExporter = $this->buildMockArticleExplorer();
 
-        $mockArticleExporter->expects($this->exactly(2))
-            ->method('getArticle')
-            ->will($this->returnValue( $this->parseResponse ));
+		$mockArticleExporter->expects($this->exactly(2))
+			->method('getArticle')
+			->will($this->returnValue( $this->parseResponse ));
 
-        $mockArticleExporter->expects($this->exactly(2))
-            ->method('getPageUrl')
-            ->will($this->returnValue( 'https://community.fandom/wiki/Jon_Snow' ));
+		$mockArticleExporter->expects($this->exactly(2))
+			->method('getPageUrl')
+			->will($this->returnValue( 'https://community.fandom/wiki/Jon_Snow' ));
 
-        $articles = $mockArticleExporter->build('1', ['1', '2']);
+		$articles = $mockArticleExporter->build('1', ['1', '2']);
 
-        $this->assertEquals(2, sizeof($articles));
-    }
+		$this->assertEquals(2, sizeof($articles));
+	}
 
-    public function testGetPlaintext() {
-        $plaintext = $this->articleExporter->getPlaintext($this->parseResponse['parse']['text']['*']);
-        $this->assertEquals('Lorem ipsum', $plaintext);
-    }
+	public function testGetPlaintext() {
+		$plaintext = $this->articleExporter->getPlaintext($this->parseResponse['parse']['text']['*']);
+		$this->assertEquals('Lorem ipsum', $plaintext);
+	}
 
-    public function testGetCategories() {
-        $categories = $this->articleExporter->getCategories($this->parseResponse['parse']['categories']);
-        $this->assertEquals(['Character', 'Cast'], $categories);
-    }
+	public function testGetCategories() {
+		$categories = $this->articleExporter->getCategories($this->parseResponse['parse']['categories']);
+		$this->assertEquals(['Character', 'Cast'], $categories);
+	}
 
-    public function testGetPageTitles() {
-        $titles = $this->articleExporter->getPageTitles($this->parseResponse['parse']['links']);
-        $this->assertEquals(['Jon Snow', 'Ghost'], $titles);
-    }
+	public function testGetPageTitles() {
+		$titles = $this->articleExporter->getPageTitles($this->parseResponse['parse']['links']);
+		$this->assertEquals(['Jon Snow', 'Ghost'], $titles);
+	}
 
-    public function testGetUpdated() {
-        $updated = $this->articleExporter->getUpdated(0);
-        $expected = wfTimestamp( TS_ISO_8601, 0);
-        $this->assertEquals($expected, $updated);
-    }
+	public function testGetUpdated() {
+		$updated = $this->articleExporter->getUpdated(0);
+		$expected = wfTimestamp( TS_ISO_8601, 0);
+		$this->assertEquals($expected, $updated);
+	}
+
+	private function buildMockArticleExplorer() {
+		$mockArticleExporter = $this->getMockBuilder('ArticleExporter')
+			->setMethods( [ 'getArticle', 'loadTitle', 'getContentLang' ] )
+			->getMock();
+		$mockArticleExporter->expects($this->atLeastOnce())
+			->method('getContentLang')
+			->will($this->returnValue('en'));
+
+		return $mockArticleExporter;
+	}
+
+	private function buildMockTitle( $url ) {
+		$mockTitle = $this->getMockBuilder('Title')
+			->setMethods([ 'getFullUrl', 'getNamespace' ])
+			->getMock();
+		$mockTitle->expects($this->once())
+			->method('getFullUrl')
+			->will($this->returnValue( 'https://community.fandom/wiki/Jon_Snow' ));
+		$mockTitle->expects($this->once())
+			->method('getNamespace')
+			->will($this->returnValue(NS_MAIN));
+
+		return $mockTitle;
+	}
 }

--- a/includes/wikia/Extensions.php
+++ b/includes/wikia/Extensions.php
@@ -1848,6 +1848,4 @@ if ( !empty( $wgEnableTriviaQuizzesExt ) ) {
 }
 
 // LORE-519
-if ( !empty ( $wgEnableArticleExporter ) ) {
-	include "$IP/extensions/wikia/ArticleExporter/ArticleExporter.setup.php";
-}
+include "$IP/extensions/wikia/ArticleExporter/ArticleExporter.setup.php";

--- a/includes/wikia/Extensions.php
+++ b/includes/wikia/Extensions.php
@@ -1847,3 +1847,7 @@ if ( !empty( $wgEnableTriviaQuizzesExt ) ) {
     include "$IP/extensions/wikia/TriviaQuizzes/TriviaQuizzes.setup.php";
 }
 
+// LORE-519
+if ( !empty ( $wgEnableArticleExporter ) ) {
+	include "$IP/extensions/wikia/ArticleExporter/ArticleExporter.setup.php";
+}

--- a/includes/wikia/VariablesBase.php
+++ b/includes/wikia/VariablesBase.php
@@ -8978,10 +8978,3 @@ $wgEnableTriviaQuizzesExt = false;
  * @var string[] $wgTriviaQuizzesEnabledPages
  */
 $wgTriviaQuizzesEnabledPages = [];
-
-/**
- * Enables the Article Exporter API
- * @see LORE-519
- * @var bool
- */
-$wgEnableArticleExporter = false;

--- a/includes/wikia/VariablesBase.php
+++ b/includes/wikia/VariablesBase.php
@@ -8978,3 +8978,10 @@ $wgEnableTriviaQuizzesExt = false;
  * @var string[] $wgTriviaQuizzesEnabledPages
  */
 $wgTriviaQuizzesEnabledPages = [];
+
+/**
+ * Enables the Article Exporter API
+ * @see LORE-519
+ * @var bool
+ */
+$wgEnableArticleExporter = false;


### PR DESCRIPTION
# Description
For our ML classification we want to be able to get plaintext version of article content, along with some associated metadata. Similar functionality is available in `WikiaSearchIndexer`, but for large pages it's especially slow. This is a fast, not-so-thorough API that exports only the fields we need for our ML classifier.

# Example
https://gameofthrones.jshepherd.fandom-dev.us/wikia.php?controller=ArticleExporterApi&method=getArticles&ids[]=201

@Wikia/lore 