### PR TITLE
IW-1953 | Fix Google connect in Preferences

### DIFF
--- a/extensions/wikia/AuthPreferences/AuthPreferencesModuleService.php
+++ b/extensions/wikia/AuthPreferences/AuthPreferencesModuleService.php
@@ -19,7 +19,7 @@ class AuthPreferencesModuleService extends WikiaService {
 	}
 
 	public function renderAuthPreferences() {
-		global $fbAppId;
+		global $fbAppId, $wgServer;
 
 		$context = $this->getContext();
 		$out = $context->getOutput();
@@ -27,7 +27,8 @@ class AuthPreferencesModuleService extends WikiaService {
 		$out->addJsConfigVars( 'fbAppId', $fbAppId );
 		$out->addModules( 'ext.wikia.authPreferences' );
 
-		$googleConnectUrl = WikiFactory::getLocalEnvURL( 'https://www.fandom.com/google-connect' );
+		$googleConnectDomain = wfGetBaseDomainForHost( $wgServer );
+		$googleConnectUrl = WikiFactory::getLocalEnvURL( "https://www.$googleConnectDomain/google-connect" );
 		$this->setVal( 'googleConnectAuthUrl', $googleConnectUrl );
 
 		try {

--- a/extensions/wikia/AuthPreferences/AuthPreferencesModuleService.php
+++ b/extensions/wikia/AuthPreferences/AuthPreferencesModuleService.php
@@ -19,7 +19,7 @@ class AuthPreferencesModuleService extends WikiaService {
 	}
 
 	public function renderAuthPreferences() {
-		global $fbAppId, $wgServer;
+		global $fbAppId;
 
 		$context = $this->getContext();
 		$out = $context->getOutput();
@@ -27,7 +27,7 @@ class AuthPreferencesModuleService extends WikiaService {
 		$out->addJsConfigVars( 'fbAppId', $fbAppId );
 		$out->addModules( 'ext.wikia.authPreferences' );
 
-		$googleConnectUrl = WikiFactory::getLocalEnvURL( 'https://www.wikia.com/google-connect' );
+		$googleConnectUrl = WikiFactory::getLocalEnvURL( 'https://www.fandom.com/google-connect' );
 		$this->setVal( 'googleConnectAuthUrl', $googleConnectUrl );
 
 		try {


### PR DESCRIPTION
Fix an issue where the Google connect button in preferences would not display correctly because it was being loaded from wikia.com, where users no longer have an ongoing session.

https://wikia-inc.atlassian.net/browse/IW-1953