### PR TITLE
Use HOSTNAME_OVERRIDE when loading config

### DIFF
--- a/LocalSettings.php
+++ b/LocalSettings.php
@@ -399,7 +399,7 @@ $wgUserAttributeWhitelist = array_merge( $wgPublicUserAttributes, $wgPrivateUser
 require_once "$IP/includes/wikia/Emergency.php";
 
 if ( $wgDevelEnvironment && empty( $wgRunningUnitTests ) ) {
-    $wgDevBoxSettings = sprintf( '%s/../config/%s.php', $IP, gethostname() );
+    $wgDevBoxSettings = sprintf( '%s/../config/%s.php', $IP, wfGetEffectiveHostname() );
     if ( file_exists( $wgDevBoxSettings ) ) {
         require_once( $wgDevBoxSettings );
     }


### PR DESCRIPTION
We're using `HOSTNAME_OVERRIDE` to override the host name for example when running in docker. Take this into account it when loading devbox-specific config.