### PR TITLE
update routing key name

### DIFF
--- a/includes/wikia/VariablesBase.php
+++ b/includes/wikia/VariablesBase.php
@@ -8996,5 +8996,5 @@ $wgEnableArticleExporterHooks = false;
 $wgArticleExporterExchange = [
     'vhost' => '/',
     'exchange' => 'taxonomy-ex',
-    'routing' => 'taxonomy.article-edit'
+    'routing' => 'taxonomy.article-edits'
 ];


### PR DESCRIPTION
We're using the plural form in the taxonomy service

@Wikia/lore 