### PR TITLE
(PLATFORM-4082) Don't check if commenting is enabled when creating blog

### DIFF
--- a/extensions/wikia/ArticleComments/classes/ArticleComment.class.php
+++ b/extensions/wikia/ArticleComments/classes/ArticleComment.class.php
@@ -1620,7 +1620,9 @@ class ArticleComment {
 
 		// Only handle article and blog comments
 		if ( !in_array( MWNamespace::getSubject( $ns ), $commentsNS ) ||
-			!ArticleComment::isTitleComment( $title ) ) {
+			!ArticleComment::isTitleComment( $title ) ||
+			( defined( 'NS_BLOG_ARTICLE' ) && $title->inNamespace( NS_BLOG_ARTICLE ) )
+		) {
 			return true;
 		}
 


### PR DESCRIPTION
This hook was checking if commenting was enabled on a page when creating blog pages
rather than only checking when creating blog comments. This caused the hook to block
creating blog pages by other means such as via the edit API, since commenting could
not be enabled on a blog page that doesn't exist yet.

/cc @Wikia/core-platform-team 