### PR TITLE
Fix the GCS variable loading

### DIFF
--- a/extensions/wikia/WikiFactory/Loader/WikiFactoryLoader.php
+++ b/extensions/wikia/WikiFactory/Loader/WikiFactoryLoader.php
@@ -294,6 +294,9 @@ class WikiFactoryLoader {
 		/**
 		 * load balancer uses one method which demand wgContLang defined
 		 * See BugId: 12474
+		 * temporarily set it to English as $wgContLang is required when reading query paramaters
+		 * in the WebRequest class. Later on this variable is overridden with the correct language
+		 * in Setup.php
 		 */
 		$wgContLang = Language::factory( 'en' );
 

--- a/extensions/wikia/WikiFactory/Loader/WikiFactoryLoader.php
+++ b/extensions/wikia/WikiFactory/Loader/WikiFactoryLoader.php
@@ -295,7 +295,7 @@ class WikiFactoryLoader {
 		 * load balancer uses one method which demand wgContLang defined
 		 * See BugId: 12474
 		 */
-		$wgContLang = new StubObject('wgContLang');
+		$wgContLang = Language::factory( 'en' );
 
 		/**
 		 * local cache, change to CACHE_ACCEL for local


### PR DESCRIPTION
We throw 500's on prod without it. The flow is quite interesting:
* `wgContentLang` is stubbed in WFL: https://github.com/Wikia/app/blob/dev/extensions/wikia/WikiFactory/Loader/WikiFactoryLoader.php#L298
* later on in Setup.php it is overridden by the real lang object: https://github.com/Wikia/app/blob/dev/includes/Setup.php#L470
* but few lines before we do so the `SetupAfterCache` hook is triggered; VideoHandlers listen to it and they require the file repo to be initialized
* filerepo code relies on the `wgUseGcsMigrationBucketRegex` variable value
* if this value is not in memcache, we load it from the db
* somethimes we log the sql queries and we check the 'action' query parameter before doing so: https://github.com/Wikia/app/blob/dev/includes/db/Database.php#L3879
* we cannot read the query param without a valid `wgContentLang` global: https://github.com/Wikia/app/blob/dev/includes/WebRequest.php#L354
* as queries from service like `user-permissions` contain the `action` query parameter, they sometimes fail: `/api.php?action=query&format=json&list=users&usprop=groups%7Crights%7Cblockinfo&usids=32735219`
 
Exception on prod: `Class name must be a valid object or a string`
```
#0 /usr/wikia/slot1/current/src/includes/StubObject.php(66): MWFunction::newObj(NULL, Array)<br />
#1 /usr/wikia/slot1/current/src/includes/StubObject.php(105): StubObject-&gt;_newObject()<br />
#2 /usr/wikia/slot1/current/src/includes/StubObject.php(57): StubObject-&gt;_unstub('checkTitleEncod...', 5)<br />
#3 /usr/wikia/slot1/current/src/includes/StubObject.php(77): StubObject-&gt;_call('checkTitleEncod...', Array)<br />
#4 /usr/wikia/slot1/current/src/includes/WebRequest.php(354): StubObject-&gt;__call('checkTitleEncod...', Array)<br />
#5 /usr/wikia/slot1/current/src/includes/WebRequest.php(376): WebRequest-&gt;getGPCVal(Array, 'action', NULL)<br />
#6 /usr/wikia/slot1/current/src/includes/db/Database.php(3879): WebRequest-&gt;getVal('action')<br />
#7 /usr/wikia/slot1/current/src/includes/db/Database.php(3815): DatabaseBase-&gt;logSql('SELECT /* WikiF...', Object(mysqli_result), 'WikiFactory::lo...', 0.00049901008605957, false)<br />
#8 /usr/wikia/slot1/current/src/includes/db/Database.php(1024): DatabaseBase-&gt;executeAndProfileQuery('SELECT /* WikiF...', 'WikiFactory::lo...', false)<br />
#9 /usr/wikia/slot1/current/src/includes/db/Database.php(1573): DatabaseBase-&gt;query('SELECT  cv_id,c...', 'WikiFactory::lo...')<br />
#10 /usr/wikia/slot1/current/src/includes/db/Database.php(1660): DatabaseBase-&gt;select(Array, Array, Array, 'WikiFactory::lo...', Array, Array)<br />
#11 /usr/wikia/slot1/current/src/extensions/wikia/WikiFactory/WikiFactory.php(2241): DatabaseBase-&gt;selectRow(Array, Array, Array, 'WikiFactory::lo...')<br />
#12 /usr/wikia/slot1/current/src/includes/wikia/WikiaDataAccess.class.php(93): WikiFactory::{closure}()<br />
#13 /usr/wikia/slot1/current/src/includes/wikia/WikiaDataAccess.class.php(55): WikiaDataAccess::cacheWithOptions('wikicities:wiki...', Object(Closure), Array)<br />
#14 /usr/wikia/slot1/current/src/extensions/wikia/WikiFactory/WikiFactory.php(2255): WikiaDataAccess::cache('wikicities:wiki...', 86400, Object(Closure), 0)<br />
#15 /usr/wikia/slot1/current/src/extensions/wikia/WikiFactory/WikiFactory.php(1249): WikiFactory::loadVariableFromDB(false, 'wgUseGcsMigrati...', 177, false)<br />
#16 /usr/wikia/slot1/current/src/includes/wikia/Wikia.php(1579): WikiFactory::getVarValueByName('wgUseGcsMigrati...', 177)<br />
#17 /usr/wikia/slot1/current/src/includes/wikia/Wikia.php(1531): Wikia::getBackend('muppet/es')<br />
#18 /usr/wikia/slot1/current/src/includes/Hooks.php(206): Wikia::onAfterSetupLocalFileRepo(Array)<br />
#19 /usr/wikia/slot1/current/src/extensions/wikia/VideoHandlers/VideoHandlerHooks.class.php(67): Hooks::run('AfterSetupLocal...', Array)<br />
#20 /usr/wikia/slot1/current/src/includes/Hooks.php(206): VideoHandlerHooks::onSetupAfterCache()<br />
#21 /usr/wikia/slot1/current/src/includes/Setup.php(451): Hooks::run('SetupAfterCache')<br />
#22 /usr/wikia/slot1/current/src/includes/WebStart.php(166): require_once('/usr/wikia/slot...')<br />
#23 /usr/wikia/slot1/current/src/api.php(50): require('/usr/wikia/slot...')<br />
```