### PR TITLE
SER-3132 | Don't publish purge event for the whole wiki

### DIFF
--- a/extensions/wikia/ImageReview/ImageReviewEvents.setup.php
+++ b/extensions/wikia/ImageReview/ImageReviewEvents.setup.php
@@ -14,7 +14,6 @@ $wgHooks['ArticleDeleteComplete'][] = 'ImageReviewEventsHooks::onArticleDeleteCo
 $wgHooks['ArticleUndelete'][] = 'ImageReviewEventsHooks::onArticleUndelete';
 $wgHooks['OldFileDeleteComplete'][] = 'ImageReviewEventsHooks::onOldFileDeleteComplete';
 $wgHooks['OldImageRevisionVisibilityChange'][] = 'ImageReviewEventsHooks::onOldImageRevisionVisibilityChange';
-$wgHooks['CloseWikiPurgeSharedData'][] = 'ImageReviewEventsHooks::onCloseWikiPurgeSharedData';
 
 // Image Review information on file pages
 $wgHooks['ImagePageAfterImageLinks'][] = 'ImageReviewEventsHooks::onImagePageAfterImageLinks';

--- a/extensions/wikia/ImageReview/ImageReviewEventsHooks.class.php
+++ b/extensions/wikia/ImageReview/ImageReviewEventsHooks.class.php
@@ -158,11 +158,6 @@ class ImageReviewEventsHooks {
 		return true;
 	}
 
-	public static function onCloseWikiPurgeSharedData( $wikiId ) {
-		self::actionPurge( $wikiId );
-		return true;
-	}
-
 	/**
 	 * Push given image upload to the queue. This method is used by the re-queueing script.
 	 *
@@ -303,14 +298,6 @@ class ImageReviewEventsHooks {
 			$data['revisionId'] = $revisionId;
 		}
 
-		self::getRabbitConnection()->publish( self::ROUTING_KEY, $data );
-	}
-
-	private static function actionPurge( $wikiId, $action = 'purged' ) {
-		$data = [
-			'wikiId' => $wikiId,
-			'action' => $action
-		];
 		self::getRabbitConnection()->publish( self::ROUTING_KEY, $data );
 	}
 

--- a/extensions/wikia/WikiFactory/Close/close_single_wiki.php
+++ b/extensions/wikia/WikiFactory/Close/close_single_wiki.php
@@ -206,8 +206,6 @@ class CloseSingleWiki extends Maintenance {
 		 */
 		$this->doTableCleanup( $dataware, 'pages',              $cityId, 'page_wikia_id' );
 		$this->doTableCleanup( $specials, 'events_local_users', $cityId );
-
-		Hooks::run( 'CloseWikiPurgeSharedData', [ $cityId ] );
 	}
 
 	/**

--- a/extensions/wikia/WikiFactory/Close/maintenance.php
+++ b/extensions/wikia/WikiFactory/Close/maintenance.php
@@ -486,8 +486,6 @@ class CloseWikiMaintenance extends Maintenance {
 		 */
 		$this->doTableCleanup( $dataware, 'pages',              $city_id, 'page_wikia_id' );
 		$this->doTableCleanup( $specials, 'events_local_users', $city_id );
-
-		Hooks::run( 'CloseWikiPurgeSharedData', [ $city_id ] );
 	}
 
 	/**


### PR DESCRIPTION
The event wasn't acted upon for a longer while. Rather than publishing a custom event, we can rely on events for closing a wiki.