### PR TITLE
Increase NGINX FastCGI buffers size

### DIFF
--- a/docker/base/nginx.conf
+++ b/docker/base/nginx.conf
@@ -22,6 +22,9 @@ http {
     fastcgi_connect_timeout 3s;
     fastcgi_send_timeout 10s;
     fastcgi_next_upstream off; # do not retry failed requests, CDN handles that for us
+	fastcgi_buffer_size 16k;
+	fastcgi_buffers 32 16k;
+	fastcgi_busy_buffers_size 32k;
 
     log_format json_combined escape=json '{ "appname": "mediawiki-nginx-access-logs", '
       '"time_local": "$time_local", '

--- a/docker/base/nginx.conf
+++ b/docker/base/nginx.conf
@@ -22,9 +22,9 @@ http {
     fastcgi_connect_timeout 3s;
     fastcgi_send_timeout 10s;
     fastcgi_next_upstream off; # do not retry failed requests, CDN handles that for us
-	fastcgi_buffer_size 16k;
-	fastcgi_buffers 32 16k;
-	fastcgi_busy_buffers_size 32k;
+    fastcgi_buffer_size 16k;
+    fastcgi_buffers 32 16k;
+    fastcgi_busy_buffers_size 32k;
 
     log_format json_combined escape=json '{ "appname": "mediawiki-nginx-access-logs", '
       '"time_local": "$time_local", '


### PR DESCRIPTION
Increase NGINX FastCGI buffers size from defaults—based on sandbox testing, these values provide a more consistent and better performance.