### PR TITLE
PLATFORM-4127: configure the DNS timeout

### DIFF
--- a/docker/prod/prod.template.yaml
+++ b/docker/prod/prod.template.yaml
@@ -24,6 +24,10 @@ spec:
         app_version: "${APP_VERSION}"
         config_version: "${CONFIG_VERSION}"
     spec:
+      dnsConfig:
+        options:
+        - name: timeout
+          value: "1"
       containers:
         - name: nginx
           image: artifactory.wikia-inc.com/sus/mediawiki-prod-nginx:${IMAGE_TAG}
@@ -212,6 +216,10 @@ spec:
         app_version: "${APP_VERSION}"
         config_version: "${CONFIG_VERSION}"
     spec:
+      dnsConfig:
+        options:
+        - name: timeout
+          value: "1"
       containers:
         - name: nginx
           image: artifactory.wikia-inc.com/sus/mediawiki-prod-nginx:${IMAGE_TAG}

--- a/docker/sandbox/sandbox.template.yaml
+++ b/docker/sandbox/sandbox.template.yaml
@@ -22,6 +22,10 @@ spec:
         app_version: "${APP_VERSION}"
         config_version: "${CONFIG_VERSION}"
     spec:
+      dnsConfig:
+        options:
+        - name: timeout
+          value: 1
       containers:
         - name: nginx
           image: artifactory.wikia-inc.com/sus/mediawiki-sandbox-nginx:${IMAGE_TAG}

--- a/docker/sandbox/sandbox.template.yaml
+++ b/docker/sandbox/sandbox.template.yaml
@@ -25,7 +25,7 @@ spec:
       dnsConfig:
         options:
         - name: timeout
-          value: 1
+          value: "1"
       containers:
         - name: nginx
           image: artifactory.wikia-inc.com/sus/mediawiki-sandbox-nginx:${IMAGE_TAG}

--- a/docker/servicesmw/servicesmw.template.yaml
+++ b/docker/servicesmw/servicesmw.template.yaml
@@ -22,6 +22,10 @@ spec:
         app_version: "${APP_VERSION}"
         config_version: "${CONFIG_VERSION}"
     spec:
+      dnsConfig:
+        options:
+        - name: timeout
+          value: "1"
       containers:
         - name: nginx
           image: artifactory.wikia-inc.com/sus/mediawiki-servicesmw-nginx:${IMAGE_TAG}


### PR DESCRIPTION
This is set to 1s on apaches and other servers and that seem to be the reason mediawiki on k8s is less stable in case of dns issues.
https://github.com/Wikia/chef-repo/blob/master/cookbooks/discovery/templates/default/resolv.conf.erb#L7
