### PR TITLE
LORE-578 Set wgEnableArticleExporterHooks to true globally to enable the page classifier

### DIFF
--- a/includes/wikia/VariablesBase.php
+++ b/includes/wikia/VariablesBase.php
@@ -8987,7 +8987,7 @@ $wgTriviaQuizzesEnabledPages = [];
  * @see LORE-519
  * @var bool
  */
-$wgEnableArticleExporterHooks = false;
+$wgEnableArticleExporterHooks = true;
 
 /**
  * ArticleExporter RabbitMQ configuration.


### PR DESCRIPTION
https://wikia-inc.atlassian.net/browse/LORE-578

This enables the article classification edit hooks for all communities. [On edit](https://github.com/Wikia/app/blob/dev/extensions/wikia/ArticleExporter/ArticleExporterHooks.class.php#L14) a message is enqueued to rabbit that is picked up by the [`page-classification`](https://github.com/Wikia/page-classification) service.

@Wikia/fanbox 