### PR TITLE
LORE-641 | Add "isMainPage" boolean to ArticleExporter API response

### DIFF
--- a/extensions/wikia/ArticleExporter/ArticleExporter.class.php
+++ b/extensions/wikia/ArticleExporter/ArticleExporter.class.php
@@ -27,7 +27,7 @@ class ArticleExporter {
 					'categories' => $this->getCategories( $article['parse']['categories'] ),
 					'linkedPageTitles' => $this->getPageTitles( $article['parse']['links'] ),
 					'updatedUtc' => $this->getUpdated( $article['parse']['revid'] ),
-					'isHomePage' => $title->isHomePage()
+					'isHomePage' => $title->isMainPage()
 				];
 			}
 		}

--- a/extensions/wikia/ArticleExporter/ArticleExporter.class.php
+++ b/extensions/wikia/ArticleExporter/ArticleExporter.class.php
@@ -27,7 +27,7 @@ class ArticleExporter {
 					'categories' => $this->getCategories( $article['parse']['categories'] ),
 					'linkedPageTitles' => $this->getPageTitles( $article['parse']['links'] ),
 					'updatedUtc' => $this->getUpdated( $article['parse']['revid'] ),
-					'isHomePage' => $this->isHomePage()
+					'isHomePage' => $title->isHomePage()
 				];
 			}
 		}

--- a/extensions/wikia/ArticleExporter/ArticleExporter.class.php
+++ b/extensions/wikia/ArticleExporter/ArticleExporter.class.php
@@ -20,14 +20,14 @@ class ArticleExporter {
 					'lang' => $this->getContentLang(),
 					'pageId' => $id,
 					'namespace' => $title->getNamespace(),
+					'isMainPage' => $title->isMainPage(),
 					'revisionId' => strval( $article['parse']['revid'] ),
 					'title' => $article['parse']['title'],
 					'url' => $title->getFullURL(),
 					'plaintextContent' => $this->getPlaintext( $article['parse']['text']['*'] ),
 					'categories' => $this->getCategories( $article['parse']['categories'] ),
 					'linkedPageTitles' => $this->getPageTitles( $article['parse']['links'] ),
-					'updatedUtc' => $this->getUpdated( $article['parse']['revid'] ),
-					'isHomePage' => $title->isMainPage()
+					'updatedUtc' => $this->getUpdated( $article['parse']['revid'] )
 				];
 			}
 		}

--- a/extensions/wikia/ArticleExporter/ArticleExporter.class.php
+++ b/extensions/wikia/ArticleExporter/ArticleExporter.class.php
@@ -27,7 +27,7 @@ class ArticleExporter {
 					'plaintextContent' => $this->getPlaintext( $article['parse']['text']['*'] ),
 					'categories' => $this->getCategories( $article['parse']['categories'] ),
 					'linkedPageTitles' => $this->getPageTitles( $article['parse']['links'] ),
-					'updatedUtc' => $this->getUpdated( $article['parse']['revid'] )
+					'updatedUtc' => $this->getUpdated( $article['parse']['revid'] ),
 				];
 			}
 		}

--- a/extensions/wikia/ArticleExporter/ArticleExporter.class.php
+++ b/extensions/wikia/ArticleExporter/ArticleExporter.class.php
@@ -27,6 +27,7 @@ class ArticleExporter {
 					'categories' => $this->getCategories( $article['parse']['categories'] ),
 					'linkedPageTitles' => $this->getPageTitles( $article['parse']['links'] ),
 					'updatedUtc' => $this->getUpdated( $article['parse']['revid'] ),
+					'isHomePage' => $this->isHomePage()
 				];
 			}
 		}


### PR DESCRIPTION
# Description
This update includes the result of calling `isMainPage` on a `Title` object, giving a boolean answer as to whether or not the given article is the main page or not.  We need this information for properly classifying communities in the `page-classification` and `taxonomy` projects.

@Wikia/lore 