### PR TITLE
LORE-641 | ArticleExporter, change return key from `isMainPage` to `mainPage`

### DIFF
--- a/extensions/wikia/ArticleExporter/ArticleExporter.class.php
+++ b/extensions/wikia/ArticleExporter/ArticleExporter.class.php
@@ -20,7 +20,7 @@ class ArticleExporter {
 					'lang' => $this->getContentLang(),
 					'pageId' => $id,
 					'namespace' => $title->getNamespace(),
-					'isMainPage' => $title->isMainPage(),
+					'mainPage' => $title->isMainPage(),
 					'revisionId' => strval( $article['parse']['revid'] ),
 					'title' => $article['parse']['title'],
 					'url' => $title->getFullURL(),


### PR DESCRIPTION
# Description

It turns out to cause a lot of awkwardness for deserialization in Java land when you prefix the key for a boolean with `is`.  Changing the key from `isMainPage` to `mainPage` has solved this issue in testing.

@Wikia/lore 