### PR TITLE
IW | Introduce simple user-attribute gateway

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -72,7 +72,8 @@
     "tpyo/amazon-s3-php-class": "^0.5.1",
     "wikimedia/scoped-callback": "^2.0",
     "wikia/prometheus_client_php": "^0.9.2",
-    "google/cloud-storage": "^1.11"
+    "google/cloud-storage": "^1.11",
+    "guzzlehttp/guzzle": "^6.3"
   },
   "require-dev": {
     "ext-yaml": "*",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "512cd91b0d815b83fafd98b013372fb6",
+    "content-hash": "05ce899572ae16061d0ca44ea99909a1",
     "packages": [
         {
             "name": "composer/installers",

--- a/lib/Wikia/src/Factory/AttributesFactory.php
+++ b/lib/Wikia/src/Factory/AttributesFactory.php
@@ -1,14 +1,18 @@
 <?php
 namespace Wikia\Factory;
 
+use GuzzleHttp\Client;
 use User;
 use Wikia\Persistence\User\Attributes\AttributePersistence;
+use Wikia\Gateway\UserAttributeGateway;
 use Wikia\Service\User\Attributes\AttributeService;
 use Wikia\Service\User\Attributes\UserAttributes;
 
 class AttributesFactory extends AbstractFactory {
 	/** @var UserAttributes $userAttributes */
 	private $userAttributes;
+	/** @var UserAttributeGateway $userAttributeGateway */
+	private $userAttributeGateway;
 
 	public function setUserAttributes( UserAttributes $userAttributes ) {
 		$this->userAttributes = $userAttributes;
@@ -26,5 +30,17 @@ class AttributesFactory extends AbstractFactory {
 		}
 
 		return $this->userAttributes;
+	}
+
+	public function userAttributeGateway(): UserAttributeGateway {
+		if ( $this->userAttributeGateway === null ) {
+			$urlProvider = $this->serviceFactory()->providerFactory()->urlProvider();
+			$baseUrl = $urlProvider->getUrl( 'user-attribute' );
+			$httpClient = new Client( [ 'timeout' => 1.0 ] );
+
+			$this->userAttributeGateway = new UserAttributeGateway( $baseUrl, $httpClient );
+		}
+
+		return $this->userAttributeGateway;
 	}
 }

--- a/lib/Wikia/src/Gateway/UserAttributeGateway.php
+++ b/lib/Wikia/src/Gateway/UserAttributeGateway.php
@@ -1,0 +1,48 @@
+<?php
+namespace Wikia\Gateway;
+
+use GuzzleHttp\Client;
+use GuzzleHttp\Exception\ClientException;
+use GuzzleHttp\Exception\ServerException;
+use Wikia\Logger\Loggable;
+
+class UserAttributeGateway {
+	use Loggable;
+
+	/** @var string $baseUrl */
+	private $baseUrl;
+	/** @var Client $httpClient */
+	private $httpClient;
+
+	public function __construct( string $baseUrl, Client $httpClient ) {
+		$this->baseUrl = $baseUrl;
+		$this->httpClient = $httpClient;
+	}
+
+	public function getAllAttributesForMultipleUsers( array $userIds ): array {
+		$query = [];
+
+		foreach ( $userIds as $userId ) {
+			$validUserId = intval( $userId );
+
+			if ( $validUserId ) {
+				$query[] = "id=$validUserId";
+			}
+		}
+
+		try {
+			$res = $this->httpClient->get( "{$this->baseUrl}/user/bulk", [ 'query' => implode( '&', $query ) ] );
+			$body = (string)$res->getBody();
+
+			return json_decode( $body, true );
+		} catch ( ServerException $serverException ) {
+			$this->error( 'error while fetching attributes for multiple users', [ 'exception' => $serverException ] );
+		} catch ( ClientException $clientException ) {
+			if ( $clientException->getCode() !== 404 ) {
+				$this->error( 'error while fetching attributes for multiple users', [ 'exception' => $clientException ] );
+			}
+		}
+
+		return [];
+	}
+}

--- a/lib/Wikia/tests/Gateway/UserAttributeGatewayTest.php
+++ b/lib/Wikia/tests/Gateway/UserAttributeGatewayTest.php
@@ -1,0 +1,74 @@
+<?php
+namespace Wikia\Gateway;
+
+use GuzzleHttp\Client;
+use GuzzleHttp\Handler\MockHandler;
+use GuzzleHttp\HandlerStack;
+use GuzzleHttp\Middleware;
+use GuzzleHttp\Psr7\Response;
+use PHPUnit\Framework\TestCase;
+use Psr\Http\Message\RequestInterface;
+use Psr\Http\Message\ResponseInterface;
+
+class UserAttributeGatewayTest extends TestCase {
+
+	/** @var array $requestLog */
+	private $requestLog;
+
+	protected function setUp() {
+		parent::setUp();
+		$this->requestLog = [];
+	}
+
+	public function testShouldReturnAllAttributesOnSuccessForMultipleUsers() {
+		$gateway = $this->createGateway(
+			new Response( 200, [], file_get_contents( __DIR__ . '/fixtures/uas_multiple_success.json' ) )
+		);
+
+		$usersWithAttributes = $gateway->getAllAttributesForMultipleUsers( [ 5, 10 ] );
+
+		$this->assertEquals( 'Béla király', $usersWithAttributes['users'][10]['nickname'] );
+
+		$this->assertCount( 1, $this->requestLog, 'Expected to send a single request' );
+
+		foreach ( $this->requestLog as $info ) {
+			/** @var RequestInterface $request */
+			$request = $info['request'];
+
+			$this->assertEquals( '/user/bulk', $request->getUri()->getPath() );
+			$this->assertEquals( 'id=5&id=10', $request->getUri()->getQuery() );
+		}
+	}
+
+	public function testShouldReturnEmptyInfoOnClientError() {
+		$gateway = $this->createGateway(
+			new Response( 400, [], file_get_contents( __DIR__ . '/fixtures/uas_multiple_bad_request.json' ) )
+		);
+
+		$usersWithAttributes = $gateway->getAllAttributesForMultipleUsers( [ 5, 10 ] );
+
+		$this->assertEmpty( $usersWithAttributes );
+	}
+
+	public function testShouldReturnEmptyInfoOnServerError() {
+		$gateway = $this->createGateway(
+			new Response( 500, [], file_get_contents( __DIR__ . '/fixtures/uas_multiple_server_error.json' ) )
+		);
+
+		$usersWithAttributes = $gateway->getAllAttributesForMultipleUsers( [ 5, 10 ] );
+
+		$this->assertEmpty( $usersWithAttributes );
+	}
+
+	private function createGateway( ResponseInterface $response ): UserAttributeGateway {
+		$history = Middleware::history( $this->requestLog );
+
+		$handler = new MockHandler( [ $response ] );
+		$stack = HandlerStack::create( $handler );
+		$stack->push( $history );
+
+		$client =  new Client( [ 'handler' => $stack ] );
+
+		return new UserAttributeGateway( 'http://user-attribute', $client );
+	}
+}

--- a/lib/Wikia/tests/Gateway/fixtures/uas_multiple_bad_request.json
+++ b/lib/Wikia/tests/Gateway/fixtures/uas_multiple_bad_request.json
@@ -1,0 +1,4 @@
+{
+	"title": "Some client error",
+	"instance": "/"
+}

--- a/lib/Wikia/tests/Gateway/fixtures/uas_multiple_server_error.json
+++ b/lib/Wikia/tests/Gateway/fixtures/uas_multiple_server_error.json
@@ -1,0 +1,4 @@
+{
+	"title": "Some server error",
+	"instance": "/"
+}

--- a/lib/Wikia/tests/Gateway/fixtures/uas_multiple_success.json
+++ b/lib/Wikia/tests/Gateway/fixtures/uas_multiple_success.json
@@ -1,0 +1,34 @@
+{
+	"users": {
+		"5": {
+			"avatar_rev": "1395606444",
+			"website": "",
+			"occupation": "",
+			"avatar": "https://static.wikia.nocookie.net/80e07c90-bac4-470c-b24f-61f12bd0658e",
+			"UserProfilePagesV3_gender": "",
+			"fbPage": "",
+			"twitter": "",
+			"name": "",
+			"nickname": "",
+			"location": "",
+			"UserProfilePagesV3_birthday": "10-20",
+			"fancysig": "1",
+			"username": "Test user"
+		},
+		"10": {
+			"avatar_rev": "10000",
+			"website": "",
+			"occupation": "",
+			"avatar": "https://static.wikia.nocookie.net/80e07c90-bac4-470c-b24f-61f12bd0658e",
+			"UserProfilePagesV3_gender": "",
+			"fbPage": "",
+			"twitter": "",
+			"name": "Teszt Béla",
+			"nickname": "Béla király",
+			"location": "",
+			"UserProfilePagesV3_birthday": "10-20",
+			"fancysig": "1",
+			"username": "Test user 2"
+		}
+	}
+}

--- a/lib/composer/composer/autoload_classmap.php
+++ b/lib/composer/composer/autoload_classmap.php
@@ -3017,6 +3017,7 @@ return array(
     'Wikia\\Factory\\RabbitFactory' => $baseDir . '/lib/Wikia/src/Factory/RabbitFactory.php',
     'Wikia\\Factory\\ServiceFactory' => $baseDir . '/lib/Wikia/src/Factory/ServiceFactory.php',
     'Wikia\\Factory\\SwiftSyncFactory' => $baseDir . '/lib/Wikia/src/Factory/SwiftSyncFactory.php',
+    'Wikia\\Gateway\\UserAttributeGateway' => $baseDir . '/lib/Wikia/src/Gateway/UserAttributeGateway.php',
     'Wikia\\HTTP\\Response' => $baseDir . '/lib/Wikia/src/HTTP/Response.php',
     'Wikia\\Localisation\\CachedLCStoreDB' => $baseDir . '/lib/Wikia/src/Localisation/CachedLCStoreDB.php',
     'Wikia\\Localisation\\LCStoreDB' => $baseDir . '/lib/Wikia/src/Localisation/LCStoreDB.php',

--- a/lib/composer/composer/autoload_static.php
+++ b/lib/composer/composer/autoload_static.php
@@ -3553,6 +3553,7 @@ class ComposerStaticInitb367f9b4bf4d43e0d5ea402c134db26b
         'Wikia\\Factory\\RabbitFactory' => __DIR__ . '/../../..' . '/lib/Wikia/src/Factory/RabbitFactory.php',
         'Wikia\\Factory\\ServiceFactory' => __DIR__ . '/../../..' . '/lib/Wikia/src/Factory/ServiceFactory.php',
         'Wikia\\Factory\\SwiftSyncFactory' => __DIR__ . '/../../..' . '/lib/Wikia/src/Factory/SwiftSyncFactory.php',
+        'Wikia\\Gateway\\UserAttributeGateway' => __DIR__ . '/../../..' . '/lib/Wikia/src/Gateway/UserAttributeGateway.php',
         'Wikia\\HTTP\\Response' => __DIR__ . '/../../..' . '/lib/Wikia/src/HTTP/Response.php',
         'Wikia\\Localisation\\CachedLCStoreDB' => __DIR__ . '/../../..' . '/lib/Wikia/src/Localisation/CachedLCStoreDB.php',
         'Wikia\\Localisation\\LCStoreDB' => __DIR__ . '/../../..' . '/lib/Wikia/src/Localisation/LCStoreDB.php',


### PR DESCRIPTION
The Swagger-generated user-attribute client is quite cumbersome and also does not work with the bulk endpoint, as it cannot serialize query params properly. This change introduces a simple gateway using the Guzzle client so that we can use the bulk endpoint.