### PR TITLE
LORE-646 | Change ArticleExporterHooks to allow queueing of main pages using non-zero namespaces

### DIFF
--- a/extensions/wikia/ArticleExporter/ArticleExporterHooks.class.php
+++ b/extensions/wikia/ArticleExporter/ArticleExporterHooks.class.php
@@ -15,9 +15,11 @@ class ArticleExporterHooks {
         global $wgCityId;
         global $wgArticleExporterExchange;
 
-        $namespace = $page->getTitle()->getNamespace();
+        $title = $page->getTitle();
+        $namespace = $title->getNamespace();
+        $mainPage = $title->isMainPage();
 
-        if ( $namespace == NS_MAIN ) {
+        if ( $namespace == NS_MAIN || $mainPage ) {
             $message = [
                 'wikiId' => $wgCityId,
                 'pages' => [


### PR DESCRIPTION
# Description

Given that we wish to classify all main pages of communities when they are edited and that main pages do not always use the namespace 0, we need to update our page-editing queueing mechanism to allow for non-zero namespaces in the instance that the edited page is a main page.

This PR makes that change.  Tested on devbox editing a main page with a non-zero namespace (which queued) and a non main page with a non-zero namespace (which did not queue).

@Wikia/lore 