### PR TITLE
SER-3259 | Increase max_input_time 60 -> 180s

### DIFF
--- a/docker/base/php.ini
+++ b/docker/base/php.ini
@@ -12,7 +12,8 @@ disable_classes =
 zend.enable_gc = On
 expose_php = Off
 max_execution_time = 180
-max_input_time = 60
+; SER-3259 - uploads are failing for users on slower connections
+max_input_time = 180
 memory_limit = 200M
 error_reporting = E_ALL & ~E_DEPRECATED & ~E_STRICT
 display_errors = Off

--- a/includes/filerepo/backend/GcsFileBackend.php
+++ b/includes/filerepo/backend/GcsFileBackend.php
@@ -21,7 +21,7 @@ class GcsFileBackend extends FileBackendStore {
 		parent::__construct( $config );
 		$this->bucketName = $config['gcsBucket'];
 		$this->temporaryBucketName = $config['gcsTemporaryBucket'];
-		$this->storage = new StorageClient( [ 'keyFile' => $config['gcsCredentials'] ] );
+		$this->storage = new StorageClient( [ 'requestTimeout' => 180, 'keyFile' => $config['gcsCredentials'] ] );
 		$this->gcsPaths = new GcsPathFactory( $config['gcsObjectNamePrefix'] );
 	}
 


### PR DESCRIPTION
Recently we've seen an increase in users complaining about failed image uploads, such as via Special:Upload - seeing an 'I/O error' or 'ERR_SPDY_PROTOCOL_ERROR' message afterwards.

These users are on slower connections (e.g. <0.5 Mbps), trying to upload files over ~5 MB in size.

https://wikia-inc.atlassian.net/browse/SER-3259