### PR TITLE
Update k8s-deployer image to latest version

### DIFF
--- a/docker/prod/Jenkinsfile
+++ b/docker/prod/Jenkinsfile
@@ -1,4 +1,4 @@
-def kubectlImage = "artifactory.wikia-inc.com/ops/k8s-deployer:0.0.15"
+def kubectlImage = "artifactory.wikia-inc.com/ops/k8s-deployer:0.0.21"
 def nginxImage = "artifactory.wikia-inc.com/sus/mediawiki-prod-nginx"
 def mediawikiImage = "artifactory.wikia-inc.com/sus/mediawiki-php"
 def loggerImage = "artifactory.wikia-inc.com/sus/mediawiki-logger"


### PR DESCRIPTION
We need newest version to avoid errors like this:
```
error: SchemaError(io.k8s.api.apps.v1.DeploymentCondition): invalid object doesn't have additional properties
```