### PR TITLE
DE-4421 | add pdo_pgsql to MediaWiki base Docker image

### DIFF
--- a/docker/README.md
+++ b/docker/README.md
@@ -4,8 +4,8 @@ We assume that you have `app` and `config` repository cloned in the same directo
 
 ```sh
 # 1. build a base image
-docker build -f base/Dockerfile -t artifactory.wikia-inc.com/sus/php-wikia-base:225a68a ./base
-docker push artifactory.wikia-inc.com/sus/php-wikia-base:225a68a
+docker build -f base/Dockerfile -t artifactory.wikia-inc.com/sus/php-wikia-base:06b60d8 ./base
+docker push artifactory.wikia-inc.com/sus/php-wikia-base:06b60d8
 
 # 2. and then dev image
 docker build -f dev/Dockerfile -t php-wikia-dev ./dev

--- a/docker/base/Dockerfile
+++ b/docker/base/Dockerfile
@@ -35,6 +35,8 @@ RUN apt-get update && apt-get install -y \
     default-mysql-client \
     # SUS-5807 | required by DumpsOnDemandTask
     p7zip-full \
+    # DE-4421 | required by pdo_pqsql
+    libpq-dev \
     # needed by sass, this installs libsass-3.4.3, matches with https://github.com/absalomedia/sassphp/releases/tag/0.5.10
     && apt-get install -y libsass-dev \
     # cleanup
@@ -116,6 +118,8 @@ RUN apt-get update && apt-get install -y \
     intl \
     # required by Exif.php class to render file's metdata
     exif \
+    # DE-4421 | pgsql client is needed to connect to Amazon's Redshift
+    pdo pdo_pgsql \
     # remove no longer needed dependencies
     && apt-get remove -y \
         automake \
@@ -135,6 +139,6 @@ ENV WIKIA_DOCROOT=/usr/wikia/slot1/current/src
 ENV WIKIA_CONFIG_ROOT=/usr/wikia/slot1/current/config
 
 # run "sha1sum * | sha1sum" to update this value when this file (or any other in this directory) changes
-ENV WIKIA_BASE_IMAGE_HASH=225a68a
+ENV WIKIA_BASE_IMAGE_HASH=06b60d8
 
 WORKDIR /usr/wikia/slot1/current/src

--- a/docker/base/Dockerfile-php
+++ b/docker/base/Dockerfile-php
@@ -1,5 +1,5 @@
 # This is a base Docker image used in prod/preview Jenkinsfile
-FROM artifactory.wikia-inc.com/sus/php-wikia-base:225a68a
+FROM artifactory.wikia-inc.com/sus/php-wikia-base:06b60d8
 
 ADD app /usr/wikia/slot1/current/src
 ADD config /usr/wikia/slot1/current/config

--- a/docker/dev/Dockerfile
+++ b/docker/dev/Dockerfile
@@ -1,6 +1,6 @@
 # This is a Docker image for  Wikia's MediaWiki app that can be used locally by a developer.
 # Simply mount your app and config repositories clone (refer to README.md)
-FROM artifactory.wikia-inc.com/sus/php-wikia-base:225a68a
+FROM artifactory.wikia-inc.com/sus/php-wikia-base:06b60d8
 
 # install dev dependencies
 

--- a/docker/qa/Dockerfile-rebuild-test-mw
+++ b/docker/qa/Dockerfile-rebuild-test-mw
@@ -1,5 +1,5 @@
 # This is a base Docker image used in prod/sandbox/preview Jenkinsfile
-FROM artifactory.wikia-inc.com/sus/php-wikia-base:225a68a
+FROM artifactory.wikia-inc.com/sus/php-wikia-base:06b60d8
 
 # disable the opcache
 RUN sed -i 's/zend_extension=/;zend_extension=/g' /usr/local/etc/php/conf.d/docker-php-ext-opcache.ini

--- a/docker/sandbox/Dockerfile-debug
+++ b/docker/sandbox/Dockerfile-debug
@@ -17,7 +17,7 @@ RUN npm install
 RUN npm run build --production
 
 # This is a base Docker image used in sandbox Jenkinsfile
-FROM artifactory.wikia-inc.com/sus/php-wikia-base:225a68a
+FROM artifactory.wikia-inc.com/sus/php-wikia-base:06b60d8
 
 # disable the opcache
 RUN sed -i 's/zend_extension=/;zend_extension=/g' /usr/local/etc/php/conf.d/docker-php-ext-opcache.ini


### PR DESCRIPTION
https://wikia-inc.atlassian.net/browse/DE-4421

We need `pgsql` client in MediaWiki to connect to Amazon's Redshift.

```
nobody@5b466532d433:/usr/wikia/slot1/current/src$ php -m | grep -i pdo
PDO
pdo_pgsql
pdo_sqlite
```

```
PDO

PDO support => enabled
PDO drivers => sqlite, pgsql

pdo_pgsql

PDO Driver for PostgreSQL => enabled
PostgreSQL(libpq) Version => 9.6.13
Module version => 7.0.30
Revision =>  $Id: cffaf82eabbf77d05dd06589b673fe0e69bc87ab $ 

pdo_sqlite

PDO Driver for SQLite 3.x => enabled
SQLite Library => 3.14.2
```