### PR TITLE
Devbox docker | use the same php-wikia-base image

### DIFF
--- a/docker/devbox/Dockerfile
+++ b/docker/devbox/Dockerfile
@@ -1,6 +1,6 @@
 # This is a Docker image for  Wikia's MediaWiki app that can be used on devboxes.
 # Simply mount your app and config repositories clone (refer to README.md)
-FROM artifactory.wikia-inc.com/sus/php-wikia-base:da4390f
+FROM artifactory.wikia-inc.com/sus/php-wikia-base:06b60d8
 
 # install dev dependencies
 

--- a/docker/devbox/Dockerfile-tests
+++ b/docker/devbox/Dockerfile-tests
@@ -1,6 +1,6 @@
 # This is a Docker image for  Wikia's MediaWiki app that can be used on devboxes.
 # Simply mount your app and config repositories clone (refer to README.md)
-FROM artifactory.wikia-inc.com/sus/php-wikia-base:959312e
+FROM artifactory.wikia-inc.com/sus/php-wikia-base:06b60d8
 
 # install dev dependencies
 


### PR DESCRIPTION
See #17230

```
sandbox/Dockerfile-debug
20:FROM artifactory.wikia-inc.com/sus/php-wikia-base:06b60d8

devbox/Dockerfile-tests
3:FROM artifactory.wikia-inc.com/sus/php-wikia-base:06b60d8

devbox/Dockerfile
3:FROM artifactory.wikia-inc.com/sus/php-wikia-base:06b60d8

qa/Dockerfile-rebuild-test-mw
2:FROM artifactory.wikia-inc.com/sus/php-wikia-base:06b60d8

base/Dockerfile-php
2:FROM artifactory.wikia-inc.com/sus/php-wikia-base:06b60d8

README.md
7:docker build -f base/Dockerfile -t artifactory.wikia-inc.com/sus/php-wikia-base:06b60d8 ./base
8:docker push artifactory.wikia-inc.com/sus/php-wikia-base:06b60d8

dev/Dockerfile
3:FROM artifactory.wikia-inc.com/sus/php-wikia-base:06b60d8
```