### PR TITLE
IW | Fix discussion log links for anons

### DIFF
--- a/extensions/wikia/SpecialDiscussionsLog/SpecialDiscussionsLogHooks.class.php
+++ b/extensions/wikia/SpecialDiscussionsLog/SpecialDiscussionsLogHooks.class.php
@@ -4,12 +4,24 @@
  * Discussion user log hooks
  */
 class SpecialDiscussionsLogHooks {
-	public static function onContributionsToolLinks( $id, $nt, &$tools ) {
-		global $wgServer, $wgScriptPath;
+	private static function getDiscussionLogQueryParamsFromTarget( Title $target ): array {
+		$targetName = $target->getText();
+		$targetUserId = User::idFromName( $targetName );
 
-		if ( F::app()->wg->User->isAllowed( 'specialdiscussionslog' ) ) {
+		if ( $targetUserId ) {
+			return [ 'username' => $targetName ];
+		}
+
+		return [ 'ip' => $targetName ];
+	}
+
+	public static function onContributionsToolLinks( $id, Title $nt, &$tools ) {
+		global $wgServer, $wgScriptPath, $wgUser;
+
+		if ( $wgUser->isAllowed( 'specialdiscussionslog' ) ) {
+			$query = http_build_query( self::getDiscussionLogQueryParamsFromTarget( $nt ) );
 			$tools[] = Linker::makeExternalLink(
-				$wgServer . $wgScriptPath . '/d/log?username=' . User::newFromId( $id )->getName(),
+				$wgServer . $wgScriptPath . '/d/log?' . $query,
 				wfMessage( 'discussionslog-contributions-link-title' )->escaped()
 			);
 		}


### PR DESCRIPTION
The link to global discussions log points to the wrong place when viewing an anonymous user's contribution page. In this case, it should pass the anonymous user's IP address as the `ip` query param.