### PR TITLE
Correct maintenance script path

### DIFF
--- a/docker/maintenance/founder-emails-days-passed.yaml
+++ b/docker/maintenance/founder-emails-days-passed.yaml
@@ -2,5 +2,5 @@ schedule: "20 20 * * *"
 server_id: 1802109 # sus.wikia.com
 args:
 - php
-- /usr/wikia/slot1/current/src/extensions/wikia/FounderEmails/FounderEmailMaintenance.php
+- /usr/wikia/slot1/current/src/extensions/wikia/FounderEmails/FounderEmailsMaintenance.php
 - --event=daysPassed


### PR DESCRIPTION
Kibana logs says: `Could not open input file: /usr/wikia/slot1/current/src/extensions/wikia/FounderEmails/FounderEmailMaintenance.php` and it right, there is a missing `s` :)