### PR TITLE
SpecialAnalytics: use $wgLang to differ the cache based on user language

### DIFF
--- a/extensions/wikia/Hydralytics/specials/SpecialAnalytics.php
+++ b/extensions/wikia/Hydralytics/specials/SpecialAnalytics.php
@@ -65,9 +65,10 @@ class SpecialAnalytics extends \SpecialPage {
 	 * @throws \ErrorPageError
 	 */
 	private function analyticsPage() {
-		global $wgMemc;
+		global $wgMemc, $wgLang;
 
-		$memcKey = wfMemcKey( __CLASS__, self::CACHE_VERSION );
+		// use $wgLang to differ the cache based on user language
+		$memcKey = wfMemcKey( __CLASS__, self::CACHE_VERSION, $wgLang->getCode() );
 		$sections = $wgMemc->get( $memcKey );
 
 		if ( !is_array( $sections ) ) {


### PR DESCRIPTION
Different values of user language (or `uselang` URL parameter) will use a different memcache key.