### PR TITLE
Travis xenial

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: php
 php: 7.0
-dist: trusty
+dist: xenial
 sudo: required
 addons:
   apt:

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,6 +16,7 @@ addons:
       - libmustache-dev
 services:
   - rabbitmq
+  - mysql
 install:
   - pecl channel-update pecl.php.net
   - pecl install uopz-5.0.2 mustache-0.7.4

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,10 +5,10 @@ sudo: required
 addons:
   apt:
     sources:
-      # same as mysql-5.7-trusty travis alias, but you can't mix & match different source declaration types
-      - sourceline: "deb http://repo.mysql.com/apt/ubuntu/ trusty mysql-5.7"
+      # same as mysql-5.7-xenial travis alias, but you can't mix & match different source declaration types
+      - sourceline: "deb http://repo.mysql.com/apt/ubuntu/ xenial mysql-5.7"
         key_url: "http://keyserver.ubuntu.com/pks/lookup?op=get&search=0x8C718D3B5072E1F5"
-      - sourceline: "deb http://ppa.launchpad.net/jbboehr/mustache/ubuntu trusty main"
+      - sourceline: "deb http://ppa.launchpad.net/jbboehr/mustache/ubuntu xenial main"
         key_url: "http://keyserver.ubuntu.com/pks/lookup?op=get&search=0x7DAD64617A3EC228D368C50F9A90195D619F9E2B"
     packages:
       - mysql-server


### PR DESCRIPTION
Due to expired git-lfs key we cannot really install mysql in trusty image. and adding new key in the `addons: apt` section is not possible.
I've found out the easiest way of fixing travis tests is to use xenial.