### PR TITLE
SER-3347 Not use numeric keys in getRemoveStatus

### DIFF
--- a/extensions/wikia/Privacy/RemoveUserDataController.php
+++ b/extensions/wikia/Privacy/RemoveUserDataController.php
@@ -1,6 +1,7 @@
 <?php
 
 use Wikia\Logger\Loggable;
+use Wikia\Logger\WikiaLogger;
 
 class RemoveUserDataController extends WikiaController {
 	use Loggable;
@@ -103,6 +104,12 @@ class RemoveUserDataController extends WikiaController {
 				$this->okResponse( $userId, $logEntry->id, $logEntry->created, true );
 				return;
 			}
+		}
+
+		if (!isset($logEntries[ 0 ])) {
+			WikiaLogger::instance()->info( __METHOD__ . ' logEntries has no first element when it should', [
+				'logEntries' => json_encode( $logEntries ),
+			] );
 		}
 
 		// if all log entries are unsuccessful, return the latest fail


### PR DESCRIPTION
In some cases `$logEntries[0]` throws an undefined offset notice - there is an empty check before so it shouldn't be empty. I thought maybe using array pointer will fix it.