### PR TITLE
PLATFORM-4216: limit elasticsearch cardinality for mediawiki index

### DIFF
--- a/extensions/Scribunto/engines/LuaCommon/LuaCommon.php
+++ b/extensions/Scribunto/engines/LuaCommon/LuaCommon.php
@@ -67,6 +67,10 @@ abstract class Scribunto_LuaEngine extends ScribuntoEngineBase {
 		// Wikia change - begin
 		$ex = new Scribunto_LuaError( $message, $this->getDefaultExceptionParams() + $params );
 
+		// PLATFORM-4216 - try to limit ES index cardinality
+		if ( isset( $params['trace'] ) ) {
+			$params['trace'] = json_encode( $params['trace'] );
+		}
 		Wikia\Logger\WikiaLogger::instance()->error( __METHOD__, [
 			'exception' => $ex,
 			'lua_message' => $ex->getLuaMessage(),

--- a/extensions/VisualEditor/ApiVisualEditor.php
+++ b/extensions/VisualEditor/ApiVisualEditor.php
@@ -126,7 +126,7 @@ class ApiVisualEditor extends ApiBase {
 			}
 			\Wikia\Logger\WikiaLogger::instance()->error( 'ApiVisualEditor_requestParsoid', [
 				'method' => $method,
-				'error_messages' => json_encode($errors),
+				'error_message' => json_encode($errors),
 				'status_code' => $req->getStatus()
 			] );
 			$this->dieUsage( "$message: " . $req->getContent(), 'parsoidserver-' . $code );

--- a/extensions/wikia/ArticleAsJson/ArticleAsJson.class.php
+++ b/extensions/wikia/ArticleAsJson/ArticleAsJson.class.php
@@ -754,7 +754,7 @@ class ArticleAsJson {
 				\Wikia\Logger\WikiaLogger::instance()->notice(
 					'ArticleAsJson - Media width was empty - fallback to fallbackSize',
 					[
-						'media_details' => $mediaDetail,
+						'media_details' => json_encode( $mediaDetail ),
 						'fallback_size' => $fallbackSize
 					]
 				);
@@ -766,7 +766,7 @@ class ArticleAsJson {
 				\Wikia\Logger\WikiaLogger::instance()->notice(
 					'ArticleAsJson - Media height was empty - fallback to fallbackSize',
 					[
-						'media_details' => $mediaDetail,
+						'media_details' => json_encode( $mediaDetail ),
 						'fallback_size' => $fallbackSize
 					]
 				);

--- a/extensions/wikia/Forum/RelatedForumDiscussionController.class.php
+++ b/extensions/wikia/Forum/RelatedForumDiscussionController.class.php
@@ -39,8 +39,8 @@ class RelatedForumDiscussionController extends WikiaService {
 			$wikiaPage = WikiPage::newFromID( $id );
 			if ( $wikiaPage ) {
 				$wikiaPage->doPurge();
-				self::logError( "Found a null related wikipage on thread purge", [ "articleId" => $id, "threadId" => $threadId ] );
 			} else {
+				self::logError( "Found a null related wikipage on thread purge", [ "articleId" => $id, "threadId" => $threadId ] );
 			}
 		}
 	}

--- a/extensions/wikia/Forum/RelatedForumDiscussionController.class.php
+++ b/extensions/wikia/Forum/RelatedForumDiscussionController.class.php
@@ -39,9 +39,8 @@ class RelatedForumDiscussionController extends WikiaService {
 			$wikiaPage = WikiPage::newFromID( $id );
 			if ( $wikiaPage ) {
 				$wikiaPage->doPurge();
+				self::logError( "Found a null related wikipage on thread purge", [ "articleId" => $id, "threadId" => $threadId ] );
 			} else {
-				self::logError( "Found a null related wikipage on thread purge", [ "articleId" =>
-																					   $id, "threadId" => $threadId ] );
 			}
 		}
 	}

--- a/extensions/wikia/Forum/RelatedForumDiscussionController.class.php
+++ b/extensions/wikia/Forum/RelatedForumDiscussionController.class.php
@@ -40,7 +40,8 @@ class RelatedForumDiscussionController extends WikiaService {
 			if ( $wikiaPage ) {
 				$wikiaPage->doPurge();
 			} else {
-				self::logError( "Found a null related wikipage on thread purge", [ "articleID" => $id, "threadID" => $threadId ] );
+				self::logError( "Found a null related wikipage on thread purge", [ "articleId" =>
+																					   $id, "threadId" => $threadId ] );
 			}
 		}
 	}

--- a/extensions/wikia/Wall/builders/WallMessageBuilder.class.php
+++ b/extensions/wikia/Wall/builders/WallMessageBuilder.class.php
@@ -262,7 +262,7 @@ class WallMessageBuilder extends WallBuilder {
 				'parentPageTitle' => $this->parentPageTitle->getPrefixedText(),
 				'parentPageId' => $this->parentPageTitle->getArticleID(),
 				'parentMessageTitle' => $this->parentMessage ? $this->parentMessage->getTitle()->getPrefixedText() : '',
-				'parentMessageId' => $this->parentMessage ? $this->parentMessage->getId() : '',
+				'parentMessageId' => $this->parentMessage ? strval( $this->parentMessage->getId() ) : '',
 			]);
 
 		throw new $class( $message, $context );

--- a/extensions/wikia/WikiFactory/Loader/WikiFactoryLoader.php
+++ b/extensions/wikia/WikiFactory/Loader/WikiFactoryLoader.php
@@ -167,13 +167,13 @@ class WikiFactoryLoader {
 			// PLATFORM-4104 on apaches log request details
 			$log = \Wikia\Logger\WikiaLogger::instance();
 			$details = [
-				'parsedUrl' => $this->parsedUrl
+				'parsedUrl' => json_encode( $this->parsedUrl )
 			];
 			foreach([
 				'HTTP_X_WIKIA_INTERNAL_REQUEST' => 'wikiaInternalRequest',
 				'HTTP_USER_AGENT' => 'userAgent',
 				'HTTP_X_TRACE_ID' => 'traceId',
-				'HTTP_X_CLIENT_IP' => 'clientIp',
+				'HTTP_X_CLIENT_IP' => 'client_ip',
 				'REQUEST_URI' => 'requestUri',
 				'REQUEST_METHOD' => 'requestMethod'
 					] as $header => $key) {

--- a/extensions/wikia/WikiaWhiteList/WikiaExternalImageList.php
+++ b/extensions/wikia/WikiaWhiteList/WikiaExternalImageList.php
@@ -31,11 +31,14 @@ function wfParserExternalImagesWhiteList( &$url ) {
 	$res = wfExtImageLinksToImage($url);
 	$is_allowed = (empty($res)) ? false : ($res == $url) ? true : false;
 
+	// PLATFORM-4216 - commented out as it produces a ton of @fields keys. Re-enable with care.
+	/*
 	// SUS-1805 | collect usage statistics
 	\Wikia\Logger\WikiaLogger::instance()->info( __FUNCTION__, [
 		'url' => $url,
 		'is_allowed' => $is_allowed
 	] );
+	*/
 
 	wfProfileOut( __METHOD__ );
 	return $is_allowed;

--- a/includes/EmailNotification.php
+++ b/includes/EmailNotification.php
@@ -346,14 +346,14 @@ class EmailNotification {
 			foreach ( $userArray as $watchingUser ) {
 				if ( $this->canSendEmailToWatcher( $watchingUser, $talkUserId ) ) {
 					$this->logStep( "Sending email to watcher", [
-						"targetUserId" => $watchingUser->getId(),
+						"targetUserId" => strval( $watchingUser->getId() ),
 						"targetUser" => $watchingUser->getName(),
 						"targetUserEmail" => $watchingUser->getEmail(),
 					] );
 					$this->compose( $watchingUser );
 				} else {
 					$this->logIgnore( "Watcher does not want or cannot receive this email", [
-						"targetUserId" => $watchingUser->getId(),
+						"targetUserId" => strval( $watchingUser->getId() ),
 						"targetUser" => $watchingUser->getName(),
 						"targetUserEmail" => $watchingUser->getEmail(),
 						"targetUserEmailConfirmed" => ( $watchingUser->isEmailConfirmed()

--- a/includes/HttpFunctions.php
+++ b/includes/HttpFunctions.php
@@ -98,7 +98,7 @@ class Http {
 				'backendTimeMS' => intval( 1000 * $backendTime),
 			];
 			if ( !$isOk ) {
-				$params[ 'responseHeaders' ] = $req->getResponseHeaders();
+				$params[ 'responseHeaders' ] = json_encode( $req->getResponseHeaders() );
 				$params[ 'reqStatus' ] = $status;
 				$params[ 'exception' ] = new Exception( $url, $req->getStatus() );
 				$level = 'error';

--- a/includes/filerepo/backend/FSFile.php
+++ b/includes/filerepo/backend/FSFile.php
@@ -196,7 +196,7 @@ class FSFile {
 		else {
 			\Wikia\Logger\WikiaLogger::instance()->warning( __METHOD__ . ' - sha1_file failed',
 				[
-					'local_path' => $this->path,
+					'local_path' => strval( $this->path ),
 					'file_exists_bool' => file_exists( $this->path )
 				]
 			);

--- a/includes/wikia/WikiaMailer.php
+++ b/includes/wikia/WikiaMailer.php
@@ -59,7 +59,8 @@ class WikiaSendgridMailer {
 
 		wfProfileIn( __METHOD__ );
 
-		$logContext = array_merge( $headers, [
+		$logContext = array_merge( [
+			'headers' => json_encode( $headers ),
 			'issue' => 'SOC-910',
 			'method' => __METHOD__,
 			'to' => $to,

--- a/includes/wikia/nirvana/WikiaDispatcher.class.php
+++ b/includes/wikia/nirvana/WikiaDispatcher.class.php
@@ -265,8 +265,8 @@ class WikiaDispatcher {
 					__METHOD__ . " - {$controllerClassName} controller dispatch exception",
 					[
 						'exception' => $e,
-						'controller_name' => $controllerClassName,
-						'method_name' => isset( $method ) ? $method : ''
+						'controller' => $controllerClassName,
+						'method' => isset( $method ) ? $method : ''
 					]
 				);
 

--- a/includes/wikia/nirvana/WikiaView.class.php
+++ b/includes/wikia/nirvana/WikiaView.class.php
@@ -361,7 +361,7 @@ class WikiaView {
 
 		if ( json_last_error() !== JSON_ERROR_NONE ) {
 			WikiaLogger::instance()->error( 'Partial JSON output rendered because of json_encode error', [
-				'error_msg' => json_last_error_msg()
+				'error_message' => json_last_error_msg()
 			] );
 		}
 

--- a/lib/Wikia/src/Service/User/Attributes/AttributeService.php
+++ b/lib/Wikia/src/Service/User/Attributes/AttributeService.php
@@ -112,7 +112,7 @@ class AttributeService {
 	 * @param $msg
 	 */
 	private function logException( $userId, \Exception $e, $msg ) {
-		$context = [ 'user' => $userId, 'exception' => $e ];
+		$context = [ 'userId' => $userId, 'exception' => $e ];
 		if ( $e instanceof PersistenceException ) {
 			$this->error( $msg, $context );
 		} else {

--- a/lib/Wikia/src/Service/User/Preferences/PreferenceService.php
+++ b/lib/Wikia/src/Service/User/Preferences/PreferenceService.php
@@ -129,7 +129,7 @@ class PreferenceService {
 
 			return $deleted;
 		} catch (\Exception $e) {
-			$this->error( $e->getMessage(), ['user' => $userId] );
+			$this->error( $e->getMessage(), ['userId' => $userId ] );
 			throw $e;
 		}
 	}
@@ -195,7 +195,7 @@ class PreferenceService {
 			try {
 				return $this->persistence->save( $userId, $prefsToSave );
 			} catch ( \Exception $e ) {
-				$this->error( $e->getMessage(), ['user' => $userId] );
+				$this->error( $e->getMessage(), ['userId' => $userId ] );
 				throw $e;
 			}
 		}
@@ -238,7 +238,7 @@ class PreferenceService {
 				$preferences = ( new UserPreferences() )
 					->setReadOnly( true );
 			} catch ( \Exception $e ) {
-				$this->error( $e->getMessage(), ['user' => $userId] );
+				$this->error( $e->getMessage(), ['userId' => $userId] );
 				throw $e;
 			}
 

--- a/lib/Wikia/src/Tasks/Tasks/CreateNewWikiTask.php
+++ b/lib/Wikia/src/Tasks/Tasks/CreateNewWikiTask.php
@@ -41,13 +41,13 @@ class CreateNewWikiTask extends BaseTask {
 		$wgErrorLog = false;
 
 		if ( $params['founderId'] ) {
-			$this->info('loading founding user', ['founder_id' => $params['founderId']]);
+			$this->info('loading founding user', ['founderId' => $params['founderId']]);
 			$this->founder = \User::newFromId( $params['founderId'] );
 			$this->founder->load();
 		}
 
 		if ( !$this->founder || $this->founder->isAnon() ) {
-			$this->warning('cannot load founding user', ['founder_id' => $params['founderId']]);
+			$this->warning('cannot load founding user', ['founderId' => $params['founderId']]);
 			if ( !empty( $params['founderName'] ) ) {
 				$this->founder = \User::newFromName( $params['founderName'] );
 				$this->founder->load();
@@ -83,19 +83,19 @@ class CreateNewWikiTask extends BaseTask {
 
 		$cmd = sprintf( "SERVER_ID={$wgCityId} php {$IP}/maintenance/update.php --server={$server} --quick --nopurge" );
 		$output = wfShellExec( $cmd, $exitStatus );
-		$this->info( 'run update.php', ['exitStatus' => $exitStatus, 'output' => $output] );
+		$this->info( 'run update.php', ['exit_status' => $exitStatus, 'output' => $output] );
 
 		$cmd = sprintf( "SERVER_ID={$wgCityId} php {$IP}/maintenance/initStats.php --server={$server}" );
 		$output = wfShellExec( $cmd, $exitStatus );
-		$this->info( 'run initStats.php', ['exitStatus' => $exitStatus, 'output' => $output] );
+		$this->info( 'run initStats.php', ['exit_status' => $exitStatus, 'output' => $output] );
 
 		$cmd = sprintf( "SERVER_ID={$wgCityId} php {$IP}/maintenance/refreshLinks.php --server={$server} --new-only" );
 		$output = wfShellExec( $cmd, $exitStatus );
-		$this->info( 'run refreshLinks.php', ['exitStatus' => $exitStatus, 'output' => $output] );
+		$this->info( 'run refreshLinks.php', ['exit_status' => $exitStatus, 'output' => $output] );
 
 		$cmd = sprintf( "SERVER_ID={$wgCityId} php {$IP}/maintenance/updateSpecialPages.php --server={$server}" );
 		$output = wfShellExec( $cmd, $exitStatus );
-		$this->info( 'run updateSpecialPages.php', ['exitStatus' => $exitStatus, 'output' => $output] );
+		$this->info( 'run updateSpecialPages.php', ['exit_status' => $exitStatus, 'output' => $output] );
 
 		// SUS-3264 | set up events_local_users entries directly, instead of calling backend script
 		$this->info( "Setting up events_local_users table entries" );
@@ -325,7 +325,7 @@ class CreateNewWikiTask extends BaseTask {
 				$this->warning( 'talkpage already exists', ['url' => $talkPage->getFullURL()] );
 			}
 		} else {
-			$this->error( "Can't take talk page for user", ['founder_id' => $this->founder->getId()] );
+			$this->error( "Can't take talk page for user", ['founderId' => $this->founder->getId()] );
 		}
 		$wgUser = $saveUser; // Restore user object after creating talk message
 		return true;

--- a/lib/Wikia/src/Tasks/Tasks/MultiTask.php
+++ b/lib/Wikia/src/Tasks/Tasks/MultiTask.php
@@ -326,7 +326,7 @@ class MultiTask extends BaseTask {
 			$this->error( 'Multi task error!', [
 				'action' => $action,
 				'server' => $row->city_server,
-				'exitStatus' => $result,
+				'exit_status' => $result,
 				'error' => $response,
 			] );
 		}


### PR DESCRIPTION
* LUA traces are the biggest offenders, pack those into a single field
* use json_encode for fields PHP arrays (like headers)
* unify field names
* resolve type conflicts
