### PR TITLE
Separate NGINX config for devboxes

### DIFF
--- a/docker/base/metrics-lua.conf
+++ b/docker/base/metrics-lua.conf
@@ -1,0 +1,13 @@
+server {
+  listen 4040;
+
+  access_log off;
+  location /metrics {
+    content_by_lua_block {
+        metric_connections:set(ngx.var.connections_reading, {"reading"})
+        metric_connections:set(ngx.var.connections_waiting, {"waiting"})
+        metric_connections:set(ngx.var.connections_writing, {"writing"})
+        prometheus:collect()
+    }
+  }
+}

--- a/docker/base/metrics.conf
+++ b/docker/base/metrics.conf
@@ -1,6 +1,4 @@
 server {
-  listen 4040;
-
   access_log off;
   location /metrics {
     vhost_traffic_status_filter_by_host off;

--- a/docker/base/metrics.conf
+++ b/docker/base/metrics.conf
@@ -3,11 +3,11 @@ server {
 
   access_log off;
   location /metrics {
-    content_by_lua_block {
-        metric_connections:set(ngx.var.connections_reading, {"reading"})
-        metric_connections:set(ngx.var.connections_waiting, {"waiting"})
-        metric_connections:set(ngx.var.connections_writing, {"writing"})
-        prometheus:collect()
-    }
+    vhost_traffic_status_filter_by_host off;
+	listen       4040;
+	location /metrics {
+	   vhost_traffic_status_display;
+	   vhost_traffic_status_display_format prometheus;
+	}
   }
 }

--- a/docker/base/nginx-lua.conf
+++ b/docker/base/nginx-lua.conf
@@ -10,13 +10,28 @@ events {
 
 
 http {
-    include       /etc/nginx/mime.types;
-	vhost_traffic_status_zone;
+    include       mime.types;
 
     client_max_body_size 0; # disable checking of client request body size
 
     default_type  application/octet-stream;
     keepalive_requests 10000;
+
+    # prometheus metrics
+    lua_shared_dict prometheus_metrics 10M;
+    lua_package_path "/usr/local/openresty/site/lualib/?.lua;/usr/local/openresty/site/wikia/?.lua;;";
+    init_by_lua_block {
+      prometheus = require("prometheus").init("prometheus_metrics")
+      metric_requests = prometheus:counter("nginx_http_requests_total", "Number of HTTP requests", {"host", "status"})
+      metric_latency = prometheus:histogram("nginx_http_request_duration_seconds", "HTTP request latency", {"host"})
+      metric_response_sizes = prometheus:histogram("nginx_http_response_size_bytes", "Response sizes in bytes", {"host"})
+      metric_connections = prometheus:gauge("nginx_http_connections", "Number of HTTP connections", {"state"})
+    }
+    log_by_lua_block {
+      metric_requests:inc(1, {ngx.var.server_name, ngx.var.status})
+      metric_latency:observe(tonumber(ngx.var.request_time), {ngx.var.server_name})
+      metric_response_sizes:observe(tonumber(ngx.var.bytes_sent), {ngx.var.server_name})
+    }
 
     # SUS-6160 | fpm settings
     # @see http://nginx.org/en/docs/http/ngx_http_fastcgi_module.html

--- a/docker/devbox/docker-compose.yml
+++ b/docker/devbox/docker-compose.yml
@@ -9,8 +9,8 @@ services:
     volumes:
       - ../base/base.inc:/etc/nginx/conf.d/base.inc:ro
       - ./site.conf:/etc/nginx/conf.d/default.conf:ro
-      - ../base/metrics.conf:/etc/nginx/conf.d/metrics.conf:ro
-      - ../base/nginx.conf:/usr/local/openresty/nginx/conf/nginx.conf:ro
+      - ../base/metrics-lua.conf:/etc/nginx/conf.d/metrics.conf:ro
+      - ../base/nginx-lua.conf:/usr/local/openresty/nginx/conf/nginx.conf:ro
       - ../../../app/skins:/usr/wikia/slot1/current/src/skins:ro
       - ../../../app/resources:/usr/wikia/slot1/current/src/resources:ro
       - ../../../app/extensions:/usr/wikia/slot1/current/src/extensions:ro


### PR DESCRIPTION
We need to separate devbox/prod/sandbox config for NGINX to avoid polluting the prod environment.