### PR TITLE
DE-XXXX | WikiAnalytics - Change text "View, Date.." etc. to always be black

### DIFF
--- a/extensions/wikia/Hydralytics/css/hydralytics.scss
+++ b/extensions/wikia/Hydralytics/css/hydralytics.scss
@@ -107,6 +107,7 @@ $fandom-link-hover-color: #005252;
 }
 
 .analytics_table th {
+	color: black;
 	text-align: left;
 	padding: 5px;
 }


### PR DESCRIPTION
Avoid situations of it being white due to community's settings against always white background

https://poznan.wikia.org/wiki/Specjalna:Analytics - grey "Views.." 
https://undertale.fandom.com/wiki/Special:Analytics - white, almost unreadable

vs fixed: https://poznan.mbalcerek-18.fandom-dev.pl/pl/wiki/Specjalna:Analytics

