### PR TITLE
(PLATFORM-4199) Don't convert external interwiki URLs to HTTPS

### DIFF
--- a/extensions/wikia/HTTPSSupport/HTTPSSupportHooks.class.php
+++ b/extensions/wikia/HTTPSSupport/HTTPSSupportHooks.class.php
@@ -70,17 +70,7 @@ class HTTPSSupportHooks {
 	 * @return boolean
 	 */
 	public static function onLinkerMakeExternalLink( string &$url, string &$text, bool &$link, array &$attribs ): bool {
-		global $wgFandomBaseDomain, $wgWikiaOrgBaseDomain, $wgWikiaBaseDomain;
-
-		$host = parse_url( $url, PHP_URL_HOST );
-
-		$normalizedHost = wfNormalizeHost( $host );
-		$explodedHost = explode( '.', $normalizedHost );
-
-		$pattern = '/(' . $wgFandomBaseDomain . '|' . $wgWikiaOrgBaseDomain . ')/';
-
-		if ( preg_match( $pattern, $normalizedHost ) || ( preg_match( '/' . $wgWikiaBaseDomain . '/', $normalizedHost ) && sizeof( $explodedHost ) <= 3 ) )
-		{
+		if ( wfHttpsAllowedForURL( $url ) ) {
 			$url = wfHttpToHttps( $url );
 		}
 		return true;

--- a/extensions/wikia/HTTPSSupport/tests/HTTPSSupportHooksTest.php
+++ b/extensions/wikia/HTTPSSupport/tests/HTTPSSupportHooksTest.php
@@ -164,7 +164,7 @@ class HTTPSSupportHooksTest extends TestCase {
 		yield [
 			'http://ja.starwars.preview.fandom.com/wiki/Yoda?key=value',
 			WIKIA_ENV_PREVIEW,
-			'https://ja.starwars.preview.fandom.com/wiki/Yoda?key=value',
+			'http://ja.starwars.preview.fandom.com/wiki/Yoda?key=value',
 		];
 		yield [
 			'http://ja.starwars.preview.wikia.com/wiki/Yoda?key=value',
@@ -172,9 +172,9 @@ class HTTPSSupportHooksTest extends TestCase {
 			'http://ja.starwars.preview.wikia.com/wiki/Yoda?key=value',
 		];
 		yield [
-			'http://starwars.sandbox-s2.fandom.com/wiki/Yoda?key=value' ,
+			'http://starwars.sandbox-s1.fandom.com/wiki/Yoda?key=value' ,
 			WIKIA_ENV_SANDBOX,
-			'https://starwars.sandbox-s2.fandom.com/wiki/Yoda?key=value',
+			'https://starwars.sandbox-s1.fandom.com/wiki/Yoda?key=value',
 		];
 		yield [
 			'http://starwars.mockdevname.fandom-dev.pl/wiki/Yoda?key=value',

--- a/includes/wikia/GlobalFunctions.php
+++ b/includes/wikia/GlobalFunctions.php
@@ -1522,7 +1522,7 @@ function wfGetStagingEnvForUrl( $url ) : string {
 }
 
 function wfHttpsAllowedForURL( $url ): bool {
-	global $wgWikiaEnvironment;
+	global $wgWikiaEnvironment, $wgWikiaBaseDomainRegex;
 	$host = parse_url( $url, PHP_URL_HOST );
 	if ( $host === false ) {
 		return false;
@@ -1530,6 +1530,9 @@ function wfHttpsAllowedForURL( $url ): bool {
 	if ( $wgWikiaEnvironment === WIKIA_ENV_PROD &&
 		isset( $_SERVER['HTTP_X_STAGING'] ) &&
 		in_array( $_SERVER['HTTP_X_STAGING'], [ 'externaltest', 'showcase' ] ) ) {
+		return false;
+	}
+	if ( !preg_match( '/' . $wgWikiaBaseDomainRegex . '$/', $host ) ) {
 		return false;
 	}
 

--- a/includes/wikia/GlobalFunctions.php
+++ b/includes/wikia/GlobalFunctions.php
@@ -1532,7 +1532,14 @@ function wfHttpsAllowedForURL( $url ): bool {
 		in_array( $_SERVER['HTTP_X_STAGING'], [ 'externaltest', 'showcase' ] ) ) {
 		return false;
 	}
-	return true;
+
+	$host = wfNormalizeHost( $host );
+	$baseDomain = wfGetBaseDomainForHost( $host );
+
+	$server = str_replace( ".$baseDomain", '', $host );
+
+	// Only allow single subdomain wikis through
+	return substr_count( $server, '.' ) === 0;
 }
 
 /**


### PR DESCRIPTION
This restores the previous behaviour of wfHttpsAllowedForURL which checks
the number of subdomains and only passes for fandom.com, wikia.com, and
wikia.org URLs. We do not support multiple subdomains over HTTPS on any
domain, and this method is used to check before modifying a URL to be
HTTPS-compatible in a number of places. This includes checking before
converting interwiki URLs to be protocol-relative.

/cc @Wikia/core-platform-team 