### PR TITLE
Restore test assertions until flag is removed

### DIFF
--- a/extensions/wikia/RobotsTxt/tests/WikiaRobotsTest.php
+++ b/extensions/wikia/RobotsTxt/tests/WikiaRobotsTest.php
@@ -171,6 +171,12 @@ class WikiaRobotsTest extends WikiaBaseTest {
 
 		$robotsTxtMock = $this->getWikiaRobotsTxt();
 
+		$this->assertTrue( $this->isNamespaceDisallowed( $robotsTxtMock, NS_SPECIAL ) );
+		$this->assertTrue( $this->isNamespaceDisallowed( $robotsTxtMock, NS_TEMPLATE ) );
+		$this->assertTrue( $this->isNamespaceDisallowed( $robotsTxtMock, NS_TEMPLATE_TALK ) );
+		$this->assertTrue( $this->isNamespaceDisallowed( $robotsTxtMock, NS_USER_TALK ) );
+		$this->assertFalse( $this->isNamespaceDisallowed( $robotsTxtMock, NS_USER ) );
+		$this->assertFalse( $this->isNamespaceDisallowed( $robotsTxtMock, NS_HELP ) );
 	}
 
 	public function testCustomRobotsRulesSingleNamespace() {
@@ -179,6 +185,13 @@ class WikiaRobotsTest extends WikiaBaseTest {
 		$this->mockGlobalVariable( 'wgRobotsTxtCustomRules', [ 'disallowNamespace' => NS_HELP ] );
 
 		$robotsTxtMock = $this->getWikiaRobotsTxt();
+
+		$this->assertTrue( $this->isNamespaceDisallowed( $robotsTxtMock, NS_SPECIAL ) );
+		$this->assertTrue( $this->isNamespaceDisallowed( $robotsTxtMock, NS_TEMPLATE ) );
+		$this->assertTrue( $this->isNamespaceDisallowed( $robotsTxtMock, NS_TEMPLATE_TALK ) );
+		$this->assertTrue( $this->isNamespaceDisallowed( $robotsTxtMock, NS_USER_TALK ) );
+		$this->assertFalse( $this->isNamespaceDisallowed( $robotsTxtMock, NS_USER ) );
+		$this->assertTrue( $this->isNamespaceDisallowed( $robotsTxtMock, NS_HELP ) );
 	}
 
 	public function testCustomRobotsRulesMultipleNamespaces() {
@@ -187,6 +200,13 @@ class WikiaRobotsTest extends WikiaBaseTest {
 		$this->mockGlobalVariable( 'wgRobotsTxtCustomRules', [ 'disallowNamespace' => [ NS_USER, NS_HELP ] ] );
 
 		$robotsTxtMock = $this->getWikiaRobotsTxt();
+
+		$this->assertTrue( $this->isNamespaceDisallowed( $robotsTxtMock, NS_SPECIAL ) );
+		$this->assertTrue( $this->isNamespaceDisallowed( $robotsTxtMock, NS_TEMPLATE ) );
+		$this->assertTrue( $this->isNamespaceDisallowed( $robotsTxtMock, NS_TEMPLATE_TALK ) );
+		$this->assertTrue( $this->isNamespaceDisallowed( $robotsTxtMock, NS_USER_TALK ) );
+		$this->assertTrue( $this->isNamespaceDisallowed( $robotsTxtMock, NS_USER ) );
+		$this->assertTrue( $this->isNamespaceDisallowed( $robotsTxtMock, NS_HELP ) );
 	}
 
 	public function testAllowedSpecialPages() {


### PR DESCRIPTION
Restore test assertions until flag for changes are removed, at which time,
these test methods should be removed entirely.

/cc @Wikia/core-platform-team 