### PR TITLE
DE-4475 | skip wikis that do not have supported city_cluster value

### DIFF
--- a/includes/wikia/api/DWDimensionApiController.class.php
+++ b/includes/wikia/api/DWDimensionApiController.class.php
@@ -447,6 +447,11 @@ class DWDimensionApiController extends WikiaApiController {
 
 		$result = [];
 		foreach( $wikis as $wiki ) {
+			// DE-4475 | skip wikis that do not have supported city_cluster value (i.e. outside the "c1...c7" range)
+			if ( !preg_match( '#^c\d+$#', $wiki['cluster'] ) ) {
+				continue;
+			}
+
 			$db = $this->getWikiConnection( $wiki[ 'cluster' ], $wiki[ 'dbname' ] );
 			$sub_result = null;
 			if ( isset( $db ) ) {


### PR DESCRIPTION
i.e. outside the `c1...c7` range

https://wikia-inc.atlassian.net/browse/DE-4475

Wiki example:

```sql
mysql@geo-db-sharedb-slave.query.consul[wikicities]>select city_id, city_dbname, city_founding_email, city_cluster, city_factory_timestamp from city_list where city_cluster = 'central';
+---------+--------------+----------------------------------+--------------+------------------------+
| city_id | city_dbname  | city_founding_email              | city_cluster | city_factory_timestamp |
+---------+--------------+----------------------------------+--------------+------------------------+
| 2043364 | mediawiki133 | ludwik.kazmierczak@wikia-inc.com | central      | 20190812112326         |
+---------+--------------+----------------------------------+--------------+------------------------+
1 row in set (0.10 sec)
```