### PR TITLE
Logger sidecar is no longer needed

### DIFF
--- a/docker/K8S_LOGGING.md
+++ b/docker/K8S_LOGGING.md
@@ -1,8 +1,0 @@
-In order for logs to be correctly processed on out kubernetes infrastructure, they MUST be printed to stdout as valid json, one log per line.
-
-Due to a problem in PHP's zlog, which causes messages to be truncated (https://github.com/php/php-src/pull/2458) and `php-fpm` adding a prefix to stdout, we had to create an external logger for our MW instances.
-MW will send logs to a socket (9999 by default), which will then be printed to stdout on a different container within the same pod.
-
-Note that this is only a problem when using FPM. Therefore, code that uses the CLI SAPI—such as maintenance scripts—can and do directly log JSON messages to stdout without using the logger sidecar.
-
-The logger's image is currently available at `artifactory.wikia-inc.com/sus/mediawiki-logger`.

--- a/docker/base/Dockerfile-logger
+++ b/docker/base/Dockerfile-logger
@@ -1,6 +1,0 @@
-FROM alpine:3.8
-
-RUN apk add --no-cache socat
-
-USER 65534:65534
-CMD ["socat", "-u", "TCP-LISTEN:9999,reuseaddr,fork", "-"]

--- a/docker/prod/Jenkinsfile
+++ b/docker/prod/Jenkinsfile
@@ -1,7 +1,6 @@
 def kubectlImage = env["K8S_DEPLOYER_IMAGE"]
 def nginxImage = "artifactory.wikia-inc.com/sus/mediawiki-prod-nginx"
 def mediawikiImage = "artifactory.wikia-inc.com/sus/mediawiki-php"
-def loggerImage = "artifactory.wikia-inc.com/sus/mediawiki-logger"
 
 def rolloutStatusSjc = 1
 def rolloutStatusRes = 1

--- a/docker/prod/prod.template.yaml
+++ b/docker/prod/prod.template.yaml
@@ -94,10 +94,8 @@ spec:
               value: "${DATACENTER}"
             - name: WIKIA_ENVIRONMENT
               value: prod
-            - name: LOG_SOCKET_ONLY
+            - name: LOG_STDOUT_ONLY
               value: "yes"
-            - name: LOG_SOCKET_ADDRESS
-              value: "tcp://localhost:9999"
           resources:
             limits:
               cpu: 5
@@ -105,16 +103,6 @@ spec:
             requests:
               cpu: 2.5
               memory: 3Gi
-        # MW log output, see K8s_LOGGING.md
-        - name: logger
-          image: artifactory.wikia-inc.com/sus/mediawiki-logger:latest
-          resources:
-            limits:
-              cpu: 100m
-              memory: 200Mi
-            requests:
-              cpu: 100m
-              memory: 50Mi
         - name: fpm-prometheus-exporter
           image: hipages/php-fpm_exporter:1.0.0
           ports:
@@ -279,10 +267,8 @@ spec:
               value: "${DATACENTER}"
             - name: WIKIA_ENVIRONMENT
               value: prod
-            - name: LOG_SOCKET_ONLY
+            - name: LOG_STDOUT_ONLY
               value: "yes"
-            - name: LOG_SOCKET_ADDRESS
-              value: "tcp://localhost:9999"
           resources:
             limits:
               cpu: 5
@@ -290,16 +276,6 @@ spec:
             requests:
               cpu: 2.5
               memory: 3Gi
-        # MW log output, see K8s_LOGGING.md
-        - name: logger
-          image: artifactory.wikia-inc.com/sus/mediawiki-logger:latest
-          resources:
-            limits:
-              cpu: 1
-              memory: 200Mi
-            requests:
-              cpu: 100m
-              memory: 50Mi
         - name: fpm-prometheus-exporter
           image: hipages/php-fpm_exporter:1.0.0
           ports:

--- a/docker/sandbox/sandbox.template.yaml
+++ b/docker/sandbox/sandbox.template.yaml
@@ -94,10 +94,8 @@ spec:
               value: "${SANDBOX_ENVIRONMENT}"
             - name: HOSTNAME_OVERRIDE
               value: "${SANDBOX_NAME}"
-            - name: LOG_SOCKET_ONLY
+            - name: LOG_STDOUT_ONLY
               value: "yes"
-            - name: LOG_SOCKET_ADDRESS
-              value: "tcp://localhost:9999"
           resources:
             limits:
               cpu: 5
@@ -105,15 +103,6 @@ spec:
             requests:
               cpu: 2.5
               memory: 3Gi
-        # MW log output, see K8s_LOGGING.md
-        - name: logger
-          image: artifactory.wikia-inc.com/sus/mediawiki-logger:latest
-          resources:
-            limits:
-              memory: 200Mi
-            requests:
-              cpu: 100m
-              memory: 50Mi
         - name: fpm-prometheus-exporter
           image: hipages/php-fpm_exporter:1.0.0
           ports:


### PR DESCRIPTION
We can log to stdout everywhere.

@Wikia/core-platform-team 