### PR TITLE
IW-2298 | Introduce API endpoint to query for users by prefix in a case-insensitive manner

### DIFF
--- a/includes/wikia/api/UserApiController.class.php
+++ b/includes/wikia/api/UserApiController.class.php
@@ -99,7 +99,7 @@ class UserApiController extends WikiaApiController {
 		$dbr = wfGetDB( DB_SLAVE, [], $wgExternalSharedDB );
 
 		// We use Latin-1 encoding to connect to our databases, but the column we're querying here uses the utf8mb4 charset.
-// Override the client character set to avoid encoding issues
+		// Override the client character set to avoid encoding issues
 		$dbr->query( 'SET NAMES utf8mb4' );
 
 		$res = $dbr->select(

--- a/includes/wikia/api/UserApiController.class.php
+++ b/includes/wikia/api/UserApiController.class.php
@@ -99,7 +99,7 @@ class UserApiController extends WikiaApiController {
 		$dbr = wfGetDB( DB_SLAVE, [], $wgExternalSharedDB );
 
 		// We use Latin-1 encoding to connect to our databases, but the column we're querying here uses the utf8mb4 charset.
-		// Override the client haracter set to avoid encoding issues
+// Override the client character set to avoid encoding issues
 		$dbr->query( 'SET NAMES utf8mb4' );
 
 		$res = $dbr->select(

--- a/includes/wikia/api/UserApiController.class.php
+++ b/includes/wikia/api/UserApiController.class.php
@@ -10,7 +10,6 @@ class UserApiController extends WikiaApiController {
 	const AVATAR_DEFAULT_SIZE = 100;
 	const USER_LIMIT = 100;
 
-	const USER_QUERY_BY_NAME_MIN_LENGTH = 3;
 	const USER_QUERY_BY_NAME_MAX_LENGTH = 255;
 	const USER_QUERY_BY_NAME_DEFAULT_LIMIT = 6;
 	const USER_QUERY_BY_NAME_MAX_LIMIT = 20;
@@ -95,11 +94,6 @@ class UserApiController extends WikiaApiController {
 
 		if ( empty( $query ) || mb_strlen( $query ) > self::USER_QUERY_BY_NAME_MAX_LENGTH ) {
 			throw new InvalidParameterApiException( 'query' );
-		}
-
-		if ( mb_strlen( $query ) < self::USER_QUERY_BY_NAME_MIN_LENGTH ) {
-			$this->response->setData( [] );
-			return;
 		}
 
 		$dbr = wfGetDB( DB_SLAVE, [], $wgExternalSharedDB );

--- a/includes/wikia/api/UserApiController.class.php
+++ b/includes/wikia/api/UserApiController.class.php
@@ -10,6 +10,11 @@ class UserApiController extends WikiaApiController {
 	const AVATAR_DEFAULT_SIZE = 100;
 	const USER_LIMIT = 100;
 
+	const USER_QUERY_BY_NAME_MIN_LENGTH = 3;
+	const USER_QUERY_BY_NAME_MAX_LENGTH = 255;
+	const USER_QUERY_BY_NAME_DEFAULT_LIMIT = 6;
+	const USER_QUERY_BY_NAME_MAX_LIMIT = 20;
+
 	/**
 	 * Get details about one or more user
 	 *
@@ -72,5 +77,54 @@ class UserApiController extends WikiaApiController {
 			throw new NotFoundApiException();
 		}
 		wfProfileOut( __METHOD__ );
+	}
+
+	/**
+	 * IW-2298: Query for user names matching a given prefix in a case-insensitive manner.
+	 *
+	 * @throws DBQueryError
+	 * @throws InvalidParameterApiException
+	 * @throws MWException
+	 */
+	public function getUsersByName(): void {
+		global $wgExternalSharedDB;
+
+		$query = $this->request->getVal( 'query' );
+		$limitFromQuery = $this->request->getInt( 'limit', self::USER_QUERY_BY_NAME_DEFAULT_LIMIT );
+		$limit = max( 1, min( self::USER_QUERY_BY_NAME_MAX_LIMIT, $limitFromQuery ) );
+
+		if ( empty( $query ) || mb_strlen( $query ) > self::USER_QUERY_BY_NAME_MAX_LENGTH ) {
+			throw new InvalidParameterApiException( 'query' );
+		}
+
+		if ( mb_strlen( $query ) < self::USER_QUERY_BY_NAME_MIN_LENGTH ) {
+			$this->response->setData( [] );
+			return;
+		}
+
+		$dbr = wfGetDB( DB_SLAVE, [], $wgExternalSharedDB );
+
+		// We use Latin-1 encoding to connect to our databases, but the column we're querying here uses the utf8mb4 charset.
+		// Override the client haracter set to avoid encoding issues
+		$dbr->query( 'SET NAMES utf8mb4' );
+
+		$res = $dbr->select(
+			'user',
+			[ 'user_id', 'user_name_normalized' ],
+			[ 'user_name_normalized ' . $dbr->buildLike( mb_strtolower( $query ), $dbr->anyString() ) ],
+			__METHOD__,
+			[ 'LIMIT' => $limit ]
+		);
+
+		$users = [];
+
+		foreach ( $res as $row ) {
+			$users[] = [
+				'id' => $row->user_id,
+				'name' => $row->user_name_normalized,
+			];
+		}
+
+		$this->response->setData( [ 'users' => $users ] );
 	}
 }

--- a/includes/wikia/api/swagger/nirvana.json
+++ b/includes/wikia/api/swagger/nirvana.json
@@ -1449,7 +1449,7 @@
         "parameters": [
           {
             "in": "query",
-            "description": "User name prefix to query for (min 3, max 255 characters)",
+            "description": "User name prefix to query for (max 255 characters)",
             "name": "query",
             "required": true,
             "type": "string",

--- a/includes/wikia/api/swagger/nirvana.json
+++ b/includes/wikia/api/swagger/nirvana.json
@@ -1429,6 +1429,44 @@
         ]
       }
     },
+    "/User/UsersByName": {
+      "get": {
+        "tags": ["user"],
+        "responses": {
+          "200": {
+            "description": "No response was specified",
+            "schema": {
+              "$ref": "UserQueryResultSet"
+            }
+          },
+          "400": {
+            "description": "Query is missing or too long"
+          }
+        },
+        "description": "",
+        "summary": "Query for users whose name matches the given prefix",
+        "operationId": "getDetails",
+        "parameters": [
+          {
+            "in": "query",
+            "description": "User name prefix to query for (min 3, max 255 characters)",
+            "name": "query",
+            "required": true,
+            "type": "string",
+            "default": ""
+          },
+          {
+            "in": "query",
+            "description": "Maximum number of results to return",
+            "name": "limit",
+            "required": false,
+            "type": "integer",
+            "format": "int32",
+            "default": "6"
+          }
+        ]
+      }
+    },
     "/WAM/MinMaxWamIndexDate": {
       "get": {
         "tags": ["wam"],
@@ -3656,6 +3694,40 @@
         "basepath": {
           "type": "string",
           "description": "Common URL prefix for relative URLs"
+        }
+      }
+    },
+    "UserQueryResultSet": {
+      "id": "UserQueryResultSet",
+      "name": "",
+      "required": [
+        "users"
+      ],
+      "properties": {
+        "users": {
+          "type": "array",
+          "description": "Standard container name for element collection (list)",
+          "items": {
+            "$ref": "#/definitions/UserQueryResultItem"
+          }
+        }
+      }
+    },
+    "UserQueryResultItem": {
+      "id": "UserQueryResultItem",
+      "name": "",
+      "required": [
+        "id", "name"
+      ],
+      "properties": {
+        "id": {
+          "type": "integer",
+          "format": "int32",
+          "description": "Wikia user ID"
+        },
+        "name": {
+          "type": "string",
+          "description": "Wikia user name (it can contain space characters)"
         }
       }
     },

--- a/includes/wikia/nirvana/WikiaView.class.php
+++ b/includes/wikia/nirvana/WikiaView.class.php
@@ -357,7 +357,7 @@ class WikiaView {
 			$output = $this->response->getData();
 		}
 
-		$json = json_encode( $output, JSON_PARTIAL_OUTPUT_ON_ERROR );
+		$json = json_encode( $output, JSON_PARTIAL_OUTPUT_ON_ERROR | JSON_UNESCAPED_UNICODE );
 
 		if ( json_last_error() !== JSON_ERROR_NONE ) {
 			WikiaLogger::instance()->error( 'Partial JSON output rendered because of json_encode error', [


### PR DESCRIPTION
Introduce API endpoint to query for users by prefix in a case-insensitive manner (as opposed to the case-sensitive [allusers API](https://www.mediawiki.org/wiki/API:Allusers)). While the principal client will be @-mentions (Feeds), I've added this to the v1 API as Pcj indicated there may be other interested clients as well.

**Do not merge** until the `user_name_normalized` column has been introduced.

https://wikia-inc.atlassian.net/browse/IW-2298