### PR TITLE
Return html with ArticleExporter response

### DIFF
--- a/extensions/wikia/ArticleExporter/ArticleExporter.class.php
+++ b/extensions/wikia/ArticleExporter/ArticleExporter.class.php
@@ -24,6 +24,7 @@ class ArticleExporter {
 					'revisionId' => strval( $article['parse']['revid'] ),
 					'title' => $article['parse']['title'],
 					'url' => $title->getFullURL(),
+					'htmlContent' => $article['parse']['text']['*'],
 					'plaintextContent' => $this->getPlaintext( $article['parse']['text']['*'] ),
 					'categories' => $this->getCategories( $article['parse']['categories'] ),
 					'linkedPageTitles' => $this->getPageTitles( $article['parse']['links'] ),


### PR DESCRIPTION
For upcoming work with infobox parsing, it'll be useful if the ArticleExporter returned a HTML response from it's API endpoint. It's auto-escaped too which is nice, example response:

```
{
  "wikiId": "1657660",
  "lang": "en",
  "pageId": "204",
  "namespace": 0,
  "mainPage": false,
  "revisionId": "276",
  "title": "Night King",
  "url": "https://gameofthrones.jshepherd-18.fandom-dev.us/wiki/Night_King",
  "htmlContent": "<p>He's a character. HE IS THE NIGHT KING OF THE NIGHT! \n</p><p>He is the mother of <a href=\"/wiki/Jon_Snow\" title=\"Jon Snow\">Jon Snow</a>. \n</p>\n<table class=\"wikia-infobox\">\n\n\n<tr>\n<th class=\"wikia-infobox-header\" colspan=\"2\"> Night King\n</th></tr>\n\n\n\n\n\n\n<tr>\n<th colspan=\"2\"> <div class=\"wikia-infobox-section-header\">Vital statistics</div>\n</th></tr>\n<tr>\n<th> Position\n</th><td> <i>Unknown</i>\n</td></tr>\n<tr>\n<th> Age\n</th><td> <i>Unknown</i>\n</td></tr>\n<tr>\n<th> Status\n</th><td> <i>Unknown</i>\n</td></tr>\n<tr>\n<th colspan=\"2\"> <div class=\"wikia-infobox-section-header\">Physical attributes</div>\n</th></tr>\n<tr>\n<th> Height\n</th><td> <i>Unknown</i>\n</td></tr>\n<tr>\n<th> Weight\n</th><td> <i>Unknown</i>\n</td></tr>\n<tr style=\"font-size:0; line-height:0;\">\n<th style=\"width:50%; padding:0\">\n</th><th style=\"width:50%; padding:0\">\n</th></tr></table>\n\n<!-- \nNewPP limit report\nPreprocessor node count: 19/300000\nPost‐expand include size: 512/2097152 bytes\nTemplate argument size: 10/2097152 bytes\nExpensive parser function count: 0/100\n-->\n\n<!-- Saved in parser cache with key gameofthrones:pcache:idhash:204-0!*!0!*!*!*!* -->\n",
  "plaintextContent": "He's a character. HE IS THE NIGHT KING OF THE NIGHT! He is the mother of Jon Snow. Night King Vital statistics Position Unknown Age Unknown Status Unknown Physical attributes Height Unknown Weight Unknown ",
  "categories": [],
  "linkedPageTitles": [
    "Jon Snow"
  ],
  "updatedUtc": "2019-06-14T16:52:53Z"
}
```

@Wikia/lore 