### PR TITLE
DE-4485 | WikiAnalytics - files with apostrophes are not clickable

### DIFF
--- a/extensions/wikia/Hydralytics/classes/Information.php
+++ b/extensions/wikia/Hydralytics/classes/Information.php
@@ -122,7 +122,7 @@ class Information {
 
 		$res = \Redshift::query(
 			'SELECT url, SUM(cnt) as views FROM wikianalytics.pageviews ' .
-			'WHERE wiki_id = :wiki_id AND url <> \'/\'  GROUP BY url ' .
+			'WHERE wiki_id = :wiki_id AND url <> \'/\' AND url LIKE \'%/wiki/%\'  GROUP BY url ' .
 			'ORDER BY views DESC LIMIT :limit',
 			[ ':wiki_id' => $wgCityId, ':limit' => $limit ]
 		);

--- a/extensions/wikia/Hydralytics/specials/SpecialAnalytics.php
+++ b/extensions/wikia/Hydralytics/specials/SpecialAnalytics.php
@@ -15,12 +15,10 @@
 
 namespace Hydralytics;
 
-use \CountryNames;
-
 class SpecialAnalytics extends \SpecialPage {
 
 	// bump this one to invalidate the Redshift results cache
-	const CACHE_VERSION = 4.2;
+	const CACHE_VERSION = 4.4;
 
 	/**
 	 * Output HTML
@@ -64,7 +62,7 @@ class SpecialAnalytics extends \SpecialPage {
 	 *
 	 * @access	private
 	 * @return	void	[Outputs to screen]
-	 * @throws \ErrorPageError
+	 * @throws \MWException
 	 */
 	private function analyticsPage() {
 		global $wgLang;
@@ -192,7 +190,7 @@ class SpecialAnalytics extends \SpecialPage {
 						$sections['top_viewed_pages'] .= "
 							<tr>
 
-								<td><a href='".wfExpandUrl($newUri)."'>". htmlspecialchars($title) . "</a></td>
+								<td><a href='".\Sanitizer::encodeAttribute(wfExpandUrl($newUri))."'>". htmlspecialchars($title) . "</a></td>
 								<td>".$this->getLanguage()->formatNum($views)."</td>
 							</tr>";
 					}
@@ -273,7 +271,8 @@ class SpecialAnalytics extends \SpecialPage {
 
 						$sections['most_visited_files'] .= "
 							<tr>
-								<td> <a href='".wfExpandUrl($newUri)."'>".urldecode($uriText)."</a></td>
+								<td><a href='".\Sanitizer::encodeAttribute(wfExpandUrl($newUri))."'>".
+								htmlspecialchars($uriText)."</a></td>
 								<td>".$this->getLanguage()->formatNum($views)."</td>
 							</tr>";
 					}

--- a/extensions/wikia/Hydralytics/specials/SpecialAnalytics.php
+++ b/extensions/wikia/Hydralytics/specials/SpecialAnalytics.php
@@ -18,7 +18,7 @@ namespace Hydralytics;
 class SpecialAnalytics extends \SpecialPage {
 
 	// bump this one to invalidate the Redshift results cache
-	const CACHE_VERSION = 4.4;
+	const CACHE_VERSION = 4.5;
 
 	/**
 	 * Output HTML


### PR DESCRIPTION
https://wikia-inc.atlassian.net/browse/DE-4485

* fix HTML encoding when rendering links
* filter out incorrect URLs when "building top viewed" articles report