### PR TITLE
IW-2525 | Add Nirvana controller for logic required by article-video service

### DIFF
--- a/extensions/wikia/ArticleVideo/ArticleVideo.setup.php
+++ b/extensions/wikia/ArticleVideo/ArticleVideo.setup.php
@@ -3,6 +3,7 @@ $wgExtensionMessagesFiles['ArticleVideo'] = __DIR__ . '/ArticleVideo.i18n.php';
 $wgAutoloadClasses['ArticleVideoContext'] = __DIR__ . '/ArticleVideoContext.class.php';
 $wgAutoloadClasses['ArticleVideoHooks'] = __DIR__ . '/ArticleVideo.hooks.php';
 $wgAutoloadClasses['ArticleVideoController'] = __DIR__ . '/ArticleVideoController.class.php';
+$wgAutoloadClasses['ArticleVideoInternalController'] = __DIR__ . '/ArticleVideoInternalController.php';
 
 $wgHooks['BeforePageDisplay'][] = 'ArticleVideoHooks::onBeforePageDisplay';
 $wgHooks['InstantGlobalsGetVariables'][] = 'ArticleVideoHooks::onInstantGlobalsGetVariables';

--- a/extensions/wikia/ArticleVideo/ArticleVideoInternalController.php
+++ b/extensions/wikia/ArticleVideo/ArticleVideoInternalController.php
@@ -1,0 +1,62 @@
+<?php
+
+/**
+ * Internal API endpoint used by the article-video service.
+ */
+class ArticleVideoInternalController extends \WikiaController {
+
+	public function init() {
+		if ( !$this->request->isInternal() ) {
+			throw new \ForbiddenException();
+		}
+	}
+
+	/**
+	 * Given a title string, return the ID of the current wiki and the ID of the corresponding article, if it exists.
+	 *
+	 * @throws \BadRequestException if the given title string is not valid
+	 * @throws \NotFoundException if the given title does not exist
+	 */
+	public function getArticleId() {
+		global $wgCityId;
+
+		$this->response->setFormat( \WikiaResponse::FORMAT_JSON );
+
+		$titleString = $this->request->getVal( 'title' );
+		$title = \Title::newFromText( $titleString );
+
+		if ( !$title ) {
+			throw new \BadRequestException( 'Invalid title.' );
+		}
+
+		if ( !$title->exists() ) {
+			throw new \NotFoundException( 'Title does not exist.' );
+		}
+
+		$this->response->setValues( [
+			'cityId' => $wgCityId,
+			'pageId' => $title->getArticleID(),
+		] );
+	}
+
+	/**
+	 * Purge video mappings cache, media details cache and CDN cache for the given article.
+	 * @throws \NotFoundException if the given article does not exist
+	 */
+	public function purgeVideoInfo() {
+		global $wgCityId;
+
+		$this->response->setFormat( \WikiaResponse::FORMAT_JSON );
+
+		$pageId = $this->request->getInt( 'pageId' );
+		$title = \Title::newFromID( $pageId );
+
+		if ( !$title ) {
+			throw new \NotFoundException( 'Title does not exist.' );
+		}
+
+		ArticleVideoService::purgeVideoMemCache( $wgCityId );
+
+		$title->purgeSquid();
+	}
+}


### PR DESCRIPTION
Currently the article-video service relies on our custom modifications to the core siteinfo API to fetch article details when saving a mapping to the database. To avoid having to patch this API in the UCP, we should create a new Nirvana controller that contains all logic the article-video service needs to call, and expose it in both the app repo and the UCP.

https://wikia-inc.atlassian.net/browse/IW-2525