### PR TITLE
Add wgEnableFeedsAndPostsExt to mobile-wiki API

### DIFF
--- a/extensions/wikia/MercuryApi/models/MercuryApi.class.php
+++ b/extensions/wikia/MercuryApi/models/MercuryApi.class.php
@@ -184,6 +184,7 @@ class MercuryApi {
 				'contentNamespaces' => array_values( $wgContentNamespaces ),
 				'defaultSkin' => $wgDefaultSkin,
 				'enableFandomAppSmartBanner' => !empty( $enableFAsmartBannerCommunity ),
+				'enableFeedsAndPosts' => $wgEnableFeedsAndPostsExt,
 				'enableEmbeddedFeedsModule' => $wgEnableFeedsAndPostsExt && $wgEnableEmbeddedFeeds,
 				'enableFilePageRedirectsForAnons' => $wgRedirectFilePagesForAnons,
 				'fandomAppSmartBannerText' => $wgFandomAppSmartBannerText,


### PR DESCRIPTION
- Add `wgEnableFeedsAndPostsExt` (via `enableFeedsAndPosts`) to `mobile-wiki` API
- This will be used by `mobile-wiki` search to determine if posts box should be visible
- Used by https://github.com/Wikia/mobile-wiki/pull/1782
- Not needed this second as the code is going to be enabled on whitelisted wikis.

@Wikia/cake 
@Wikia/iwing 