### PR TITLE
IW-2548 | add nirvana controller for LinkSuggest calls

### DIFF
--- a/extensions/wikia/LinkSuggest/LinkSuggest.class.php
+++ b/extensions/wikia/LinkSuggest/LinkSuggest.class.php
@@ -14,6 +14,7 @@ use Wikia\Measurements\Time as T;
  */
 class LinkSuggest {
 	const MAX_LINK_SUGGESTIONS_LIMIT = 100;
+	const CACHE_VERSION = 1;
 	/**
 	 * Get list of suggested images
 	 *
@@ -65,9 +66,9 @@ class LinkSuggest {
 		}
 
 		if ( $isMobile ) {
-			$key = wfMemcKey( __METHOD__, md5( $query.$limit.'_'.$request->getText('format').$request->getText('nospecial', '') ), 'WikiaMobile' );
+			$key = wfMemcKey( __METHOD__, md5( self::CACHE_VERSION.'_' .$query.$limit.'_'.$request->getText('format').$request->getText('nospecial', '').$request->getText('nsfilter', '') ), 'WikiaMobile' );
 		} else {
-			$key = wfMemcKey( __METHOD__, md5( $query.$limit.'_'.$request->getText('format').$request->getText('nospecial', '') ) );
+			$key = wfMemcKey( __METHOD__, md5( self::CACHE_VERSION.'_' .$query.$limit.'_'.$request->getText('format').$request->getText('nospecial', '').$request->getText('nsfilter', '') ) );
 		}
 
 		// use mb_strlen to test string length accurately

--- a/extensions/wikia/LinkSuggest/LinkSuggest.php
+++ b/extensions/wikia/LinkSuggest/LinkSuggest.php
@@ -47,6 +47,7 @@ $wgLinkSuggestLimit = 6;
 $wgAutoloadClasses['LinkSuggest'] = __DIR__ . '/LinkSuggest.class.php';
 $wgAutoloadClasses['LinkSuggestLoader'] = __DIR__ . '/LinkSuggestLoader.class.php';
 $wgAutoloadClasses['LinkSuggestHooks'] = __DIR__ . '/LinkSuggestHooks.class.php';
+$wgAutoloadClasses['LinkSuggestController'] = __DIR__ . '/LinkSuggestController.php';
 
 // i18n
 $wgExtensionMessagesFiles['LinkSuggest'] = __DIR__ . '/LinkSuggest.i18n.php';

--- a/extensions/wikia/LinkSuggest/LinkSuggestController.php
+++ b/extensions/wikia/LinkSuggest/LinkSuggestController.php
@@ -1,0 +1,16 @@
+<?php
+
+
+class LinkSuggestController extends WikiaApiController {
+	public function getLinkSuggestions() {
+		$output = LinkSuggest::getLinkSuggest( RequestContext::getMain()->getRequest() );
+
+		$this->response->setCacheValidity( 60 * 60 * 1000 ); // 1h
+
+		if ( $this->request->getVal('format') === 'array' ) {
+			$this->response->setData($output);
+		} else {
+			$this->response->setBody($output);
+		}
+	}
+}

--- a/includes/wikia/models/DesignSystemGlobalNavigationModel.class.php
+++ b/includes/wikia/models/DesignSystemGlobalNavigationModel.class.php
@@ -171,7 +171,7 @@ class DesignSystemGlobalNavigationModel extends WikiaModel {
 			$search['results']['url'] = $this->getPageUrl( 'Search', NS_SPECIAL, '', true );
 			$search['placeholder-active']['key'] = 'global-navigation-search-placeholder-in-wiki';
 
-			$suggestionsUrl = WikiFactory::cityIDtoUrl( $this->productInstanceId ) . '/index.php?action=ajax&rs=getLinkSuggest&format=json';
+			$suggestionsUrl = WikiFactory::cityIDtoUrl( $this->productInstanceId ) . '/wikia.php?controller=LinkSuggest&method=getLinkSuggestions&format=json';
 			$search['suggestions'] = [
 				'url' => wfProtocolUrlToRelative( $suggestionsUrl ),
 				'param-name' => 'query',

--- a/includes/wikia/models/DesignSystemGlobalNavigationModelV2.class.php
+++ b/includes/wikia/models/DesignSystemGlobalNavigationModelV2.class.php
@@ -188,7 +188,7 @@ class DesignSystemGlobalNavigationModelV2 extends WikiaModel {
 			$search['results']['url'] = $this->getPageUrl( 'Search', NS_SPECIAL, '', true );
 			$search['placeholder-active']['key'] = 'global-navigation-search-placeholder-in-wiki';
 
-			$suggestionsUrl = WikiFactory::cityIDtoUrl( $this->productInstanceId ) . '/index.php?action=ajax&rs=getLinkSuggest&format=json';
+			$suggestionsUrl = WikiFactory::cityIDtoUrl( $this->productInstanceId ) . '/wikia.php?controller=LinkSuggest&method=getLinkSuggestions&format=json';
 			$search['suggestions'] = [
 				'url' => wfProtocolUrlToRelative( $suggestionsUrl ),
 				'param-name' => 'query',


### PR DESCRIPTION
https://wikia-inc.atlassian.net/browse/IW-2548

LinkSuggest extension uses `$wgAjaxExportList` to expose http api. This feature is deprecated since MW 1.27 therefore we need to create Nirvana controller in UCP that serves the same data. For compatibility we need this controller to be present here as well

@Wikia/iwing 