### PR TITLE
(PLATFORM-4341) Prevent blocked users from modifying AbuseFilter rules

### DIFF
--- a/extensions/AbuseFilter/Views/AbuseFilterView.php
+++ b/extensions/AbuseFilter/Views/AbuseFilterView.php
@@ -30,7 +30,7 @@ abstract class AbuseFilterView extends ContextSource {
 		static $canEdit = null;
 
 		if ( is_null( $canEdit ) ) {
-			$canEdit = $wgUser->isAllowed( 'abusefilter-modify' );
+			$canEdit = !$wgUser->isBlocked() && $wgUser->isAllowed( 'abusefilter-modify' );
 		}
 
 		return $canEdit;


### PR DESCRIPTION
This is already implemented in the latest version of AbuseFilter, so should be covered
for the UCP when that is installed.

/cc @Wikia/core-platform-team 