### PR TITLE
IW-2588 | Fix cache poisoning from showcase n&s articles

### DIFF
--- a/extensions/wikia/Recirculation/services/CachedFandomArticleService.php
+++ b/extensions/wikia/Recirculation/services/CachedFandomArticleService.php
@@ -4,6 +4,8 @@ class CachedFandomArticleService implements FandomArticleService {
 
 	const CACHE_TTL_SECONDS = 900; // 15 minutes
 
+	private const CACHE_VERSION = 2;
+
 	/** @var BagOStuff $cacheService */
 	private $cacheService;
 	/** @var FandomArticleService $articleService */
@@ -15,7 +17,7 @@ class CachedFandomArticleService implements FandomArticleService {
 	}
 
 	public function getTrendingFandomArticles( int $limit ): array {
-		$key = wfSharedMemcKey( 'recirculation-trending-fandom-articles', $limit );
+		$key = wfSharedMemcKey( 'recirculation-trending-fandom-articles', self::CACHE_VERSION, $limit );
 		$cachedValue = $this->cacheService->get( $key );
 
 		if ( is_array( $cachedValue ) ) {

--- a/extensions/wikia/Recirculation/services/ParselyService.php
+++ b/extensions/wikia/Recirculation/services/ParselyService.php
@@ -7,6 +7,8 @@ class ParselyService implements FandomArticleService {
 	const REQUEST_TIMEOUT_SECONDS = 2;
 	const EXTRA_POSTS_TO_FETCH = 10;
 
+	private const FANDOM_BASE_URL = 'https://www.fandom.com';
+
 	/** @var string $baseUrl */
 	private $baseUrl;
 	/** @var string $apiKey */
@@ -33,10 +35,13 @@ class ParselyService implements FandomArticleService {
 			foreach ( $response['data'] as $postData ) {
 				$metadata = json_decode( $postData['metadata'], true );
 
+				// IW-2588: Hotfix to prevent showcase URLs from polluting the production cache
+				$articlePath = parse_url( $postData['url'], PHP_URL_PATH );
+
 				if ( isset( $metadata['postID'] ) ) {
 					$posts[$metadata['postID']] = [
 						'title' => $postData['title'],
-						'url' => $postData['url'],
+						'url' => self::FANDOM_BASE_URL . $articlePath,
 						'thumbnail' => $postData['image_url'],
 						'site_name' => static::FANDOM_SITE_NAME,
 					];


### PR DESCRIPTION
The showcase environment for N&S is treated the same as the production environment, just with a different URL. This can cause showcase URLs for N&S posts to leak into the mixed content footer. This patch works around the issue by discarding the host provided by the trending N&S articles API, and building the N&S article URL manually using the known good production host.

https://wikia-inc.atlassian.net/browse/IW-2588