### PR TITLE
IW-2588 | Fix HTTP discussion links in MCF and point them to Feeds

### DIFF
--- a/extensions/wikia/Recirculation/RecirculationController.class.php
+++ b/extensions/wikia/Recirculation/RecirculationController.class.php
@@ -26,10 +26,12 @@ class RecirculationController extends WikiaController {
 		}
 
 		if ( RecirculationHooks::canShowDiscussions( $cityId, $ignoreWgEnableRecirculationDiscussions ) ) {
-			$discussionsDataService = new DiscussionsDataService( $cityId, $limit );
+			global $wgServer, $wgScriptPath;
+			$baseUrl = $wgServer . $wgScriptPath;
+			$discussionsDataService = new DiscussionsDataService( $cityId, $limit, $baseUrl );
 			$posts = $discussionsDataService->getPosts( $sortKey );
 
-			$discussionsUrl = "$discussionsDataService->server/d/f";
+			$discussionsUrl = "$baseUrl/f";
 
 			$postObjects = [];
 

--- a/extensions/wikia/Recirculation/services/DiscussionsDataService.class.php
+++ b/extensions/wikia/Recirculation/services/DiscussionsDataService.class.php
@@ -11,8 +11,10 @@ class DiscussionsDataService {
 	const MCACHE_VER = '1.2';
 
 	private $cityId, $limit;
+	/** @var string $baseUrl */
+	private $baseUrl;
 
-	public function __construct( $cityId, $limit ) {
+	public function __construct( int $cityId, int $limit, string $baseUrl ) {
 		$this->limit = $limit;
 		$discussionsAlias = WikiFactory::getVarValueByName( 'wgRecirculationDiscussionsAlias', $cityId );
 
@@ -22,8 +24,7 @@ class DiscussionsDataService {
 			$this->cityId = $cityId;
 		}
 
-		// language-path - most likely this is ok, as the code below appends "/d/" to this value.
-		$this->server = WikiFactory::cityIDtoUrl( $this->cityId );
+		$this->baseUrl = $baseUrl;
 	}
 
 	public function getPosts( string $sortKey = self::DISCUSSIONS_API_SORT_KEY_TRENDING ): array {
@@ -101,7 +102,7 @@ class DiscussionsDataService {
 		}
 
 		return new RecirculationContent( [
-			'url' => $this->server . '/d/p/' . $rawPost['id'],
+			'url' => $this->baseUrl . '/f/p/' . $rawPost['id'],
 			'index' => $index,
 			'title' => $postTitle,
 			'publishDate' => wfTimestamp( TS_ISO_8601, $rawPost['creationDate']['epochSecond'] ),


### PR DESCRIPTION
The mixed content footer contains legacy discussions links using HTTP. They should use HTTPS and point to Feeds instead.

