### PR TITLE
fixed | and & where both operands have bool type

### DIFF
--- a/extensions/DynamicPageList/DPLMain.php
+++ b/extensions/DynamicPageList/DPLMain.php
@@ -1690,7 +1690,7 @@ class DPLMain {
 
         // addeditdate=true but not (ordermethod=...,firstedit or ordermethod=...,lastedit)
         //firstedit (resp. lastedit) -> add date of first (resp. last) revision
-        if( $bAddEditDate && !array_intersect($aOrderMethods, array('firstedit', 'lastedit')) & ($sLastRevisionBefore.$sAllRevisionsBefore.$sFirstRevisionSince.$sAllRevisionsSince == '')) {
+        if( $bAddEditDate && !array_intersect($aOrderMethods, array('firstedit', 'lastedit')) && ($sLastRevisionBefore.$sAllRevisionsBefore.$sFirstRevisionSince.$sAllRevisionsSince == '')) {
             return $output . $logger->escapeMsg(ExtDynamicPageList::FATAL_WRONGORDERMETHOD, 'addeditdate=true', 'firstedit | lastedit' );
         }
 
@@ -1700,7 +1700,7 @@ class DPLMain {
          * The fact is a page may be edited by multiple users. Which user(s) should we show? all? the first or the last one?
          * Ideally, we could use values such as 'all', 'first' or 'last' for the adduser parameter.
         */
-        if( $bAddUser && !array_intersect($aOrderMethods, array('firstedit', 'lastedit')) & ($sLastRevisionBefore.$sAllRevisionsBefore.$sFirstRevisionSince.$sAllRevisionsSince == '')) {
+        if( $bAddUser && !array_intersect($aOrderMethods, array('firstedit', 'lastedit')) && ($sLastRevisionBefore.$sAllRevisionsBefore.$sFirstRevisionSince.$sAllRevisionsSince == '')) {
             return $output . $logger->escapeMsg(ExtDynamicPageList::FATAL_WRONGORDERMETHOD, 'adduser=true', 'firstedit | lastedit' );
 		}
         if( isset($sMinorEdits) && !array_intersect($aOrderMethods, array('firstedit', 'lastedit')) )

--- a/extensions/DynamicPageList/DPLSetup.php
+++ b/extensions/DynamicPageList/DPLSetup.php
@@ -1448,7 +1448,7 @@ class ExtDynamicPageList {
         $targets = array();
         $from = '';
         $to = '';
-        if ($flip=='' | $flip=='normal')    $flip=false;
+        if ($flip=='' || $flip=='normal')    $flip=false;
         else                                $flip=true;
         if ($name=='') $name='&#160;';
         if ($yes=='') $yes= ' x ';


### PR DESCRIPTION
Bitwise ops were used probably by a mistake or because of a typo.