### PR TITLE
DE-4442 | Add marketing_allowed to DWDimensionApiController:getUsers()

### DIFF
--- a/includes/wikia/api/DWDimensionApiController.class.php
+++ b/includes/wikia/api/DWDimensionApiController.class.php
@@ -1,7 +1,9 @@
 <?php
 
+use Wikia\Factory\ServiceFactory;
 use Wikia\Service\User\Permissions\PermissionsServiceAccessor;
 use FandomCreator\CommunitySetup;
+use Wikia\Service\User\Preferences\PreferenceService;
 
 class DWDimensionApiController extends WikiaApiController {
 	use PermissionsServiceAccessor;
@@ -34,6 +36,10 @@ class DWDimensionApiController extends WikiaApiController {
 	private function getSharedDbSlave() {
 		global $wgExternalSharedDB;
 		return $this->getDbSlave( $wgExternalSharedDB );
+	}
+
+	private function userPreferencesService(): PreferenceService {
+		return ServiceFactory::instance()->preferencesFactory()->preferenceService();
 	}
 
 	public function getWikiDartTags() {
@@ -206,6 +212,14 @@ class DWDimensionApiController extends WikiaApiController {
 		$result = [];
 		$botUsers = $this->permissionsService()->getUsersInGroups( [ static::BOT_USER_GROUP ] );
 		$botGlobalUsers = $this->permissionsService()->getUsersInGroups( [ static::BOT_GLOBAL_USER_GROUP ] );
+
+		$usersWithMarketingAllowed = $this->userPreferencesService()->findUsersWithGlobalPreferenceValue(
+			'marketingallowed',
+			1,
+			$limit,
+			intval($afterUserId) >= 0 ? $afterUserId : null
+		);
+		
 		while ( $row = $db->fetchObject( $dbResult ) ) {
 			$result[] = [
 				'user_id' => $row->user_id,

--- a/includes/wikia/api/DWDimensionApiController.class.php
+++ b/includes/wikia/api/DWDimensionApiController.class.php
@@ -219,7 +219,7 @@ class DWDimensionApiController extends WikiaApiController {
 			$limit,
 			intval($afterUserId) >= 0 ? $afterUserId : null
 		);
-		
+
 		while ( $row = $db->fetchObject( $dbResult ) ) {
 			$result[] = [
 				'user_id' => $row->user_id,
@@ -229,7 +229,8 @@ class DWDimensionApiController extends WikiaApiController {
 				'user_editcount' => $row->user_editcount,
 				'user_registration' => $row->user_registration,
 				'is_bot' => isset( $botUsers[ $row->user_id ] ),
-				'is_bot_global' => isset( $botGlobalUsers[ $row->user_id ] )
+				'is_bot_global' => isset( $botGlobalUsers[ $row->user_id ] ),
+				'user_marketingallowed' => in_array( $row->user_id, $usersWithMarketingAllowed )
 			];
 		}
 		$db->freeResult( $dbResult );
@@ -286,7 +287,7 @@ class DWDimensionApiController extends WikiaApiController {
 			if ( !preg_match( '#^c\d+$#', $wiki['cluster'] ) ) {
 				continue;
 			}
-			
+
 			$db = $this->getWikiConnection( $wiki[ 'cluster' ], $wiki[ 'dbname' ] );
 			$sub_result = null;
 			if ( isset( $db ) ) {

--- a/lib/Wikia/src/Service/User/Preferences/PreferenceService.php
+++ b/lib/Wikia/src/Service/User/Preferences/PreferenceService.php
@@ -145,13 +145,15 @@ class PreferenceService {
 		}
 	}
 
-	public function findUsersWithGlobalPreferenceValue( $preferenceName, $value = null ) {
+	public function findUsersWithGlobalPreferenceValue($preferenceName, $value = null, $numUsersToRetrieve = 1000, $userIdContinue = null ) {
 		try {
-			return $this->persistence->findUsersWithGlobalPreferenceValue( $preferenceName, $value );
+			return $this->persistence->findUsersWithGlobalPreferenceValue( $preferenceName, $value, $numUsersToRetrieve, $userIdContinue );
 		} catch (\Exception $e) {
 			$this->error( $e->getMessage(), [
 				'preferenceName' => $preferenceName,
-				'value' => $value, ] );
+				'value' => $value,
+				'numUsersToRetrieve' => $numUsersToRetrieve,
+				'userIdContinue' => $userIdContinue] );
 			throw $e;
 		}
 	}


### PR DESCRIPTION
Adds a new column 'marketing_allowed' to DWDimensionApiController:getUsers() using the user-preference service.

Now uses the fixed user-preference/reverseLookup to get the preference for many users at once instead of previous attempt querying the service per each user.

