### PR TITLE
LoadBalancer: ensure connection is opened in doWait()

### DIFF
--- a/includes/db/LoadBalancer.php
+++ b/includes/db/LoadBalancer.php
@@ -144,9 +144,10 @@ class LoadBalancer {
 		wfProfileIn( __METHOD__ );
 		$this->mWaitForPos = $pos;
 		$i = $this->getReaderIndex();
+		$conn = $this->getConnection( $i );
 
 		if ( !$this->doWait( $i ) ) {
-			$this->mServers[$i]['slave pos'] = $this->getAnyOpenConnection( $i )->getSlavePos();
+			$this->mServers[$i]['slave pos'] = $conn->getSlavePos();
 			$this->mLaggedSlaveMode = true;
 		}
 		wfProfileOut( __METHOD__ );


### PR DESCRIPTION
We simplified `LoadBalancer::getReaderIndex` to eschew opening a DB connection and just return a static index for the replica DB in the server array. Accordingly, we must update `LoadBalancer::waitFor` to not assume that an open connection exists, and open a connection as needed.