### PR TITLE
LoadBalancer: only wait on connection if it exists already

### DIFF
--- a/includes/db/LoadBalancer.php
+++ b/includes/db/LoadBalancer.php
@@ -144,9 +144,9 @@ class LoadBalancer {
 		wfProfileIn( __METHOD__ );
 		$this->mWaitForPos = $pos;
 		$i = $this->getReaderIndex();
-		$conn = $this->getConnection( $i );
+		$conn = $this->getAnyOpenConnection( $i );
 
-		if ( !$this->doWait( $i ) ) {
+		if ( $conn && !$this->doWait( $i ) ) {
 			$this->mServers[$i]['slave pos'] = $conn->getSlavePos();
 			$this->mLaggedSlaveMode = true;
 		}


### PR DESCRIPTION
Previously, waitFor() would only wait on a connection if one was already open.
It would determine whether a connection was opened by checking if the reader
index was already set. As we now set the reader index unconditionally without
creating a connection, we should refactor the check to take this into account.