### PR TITLE
(PLATFORM-4386) Remove canonical tags from noindexed pages

### DIFF
--- a/extensions/wikia/CanonicalHref/CanonicalHref.php
+++ b/extensions/wikia/CanonicalHref/CanonicalHref.php
@@ -16,40 +16,10 @@ $wgExtensionCredits['specialpage'][] = array(
 	'url' => 'https://github.com/Wikia/app/tree/dev/extensions/wikia/CanonicalHref'
 );
 
+$wgAutoloadClasses[ 'CanonicalHrefHooks' ] = __DIR__ . '/CanonicalHrefHooks.php';
+
 //i18n
 $wgExtensionMessagesFiles['CanonicalHref'] = __DIR__ . '/CanonicalHref.i18n.php';
 
-$wgHooks['BeforePageDisplay'][] = 'wfCanonicalHref';
-
-/**
- * @param OutputPage $out
- * @param Skin $skin
- * @return bool
- * @throws FatalError
- * @throws MWException
- */
-function wfCanonicalHref( OutputPage $out, Skin $skin ): bool {
-	$statusCodesWithoutCanonicalHref = [ 404, 410 ];
-
-	if (
-		// No canonical on pages with pagination -- they should have the link rel="next/prev" instead
-		$out->getRequest()->getVal( 'page' ) ||
-		// SUS-5546: Don't render a canonical href for the closed wiki page
-		$out->getTitle()->isSpecial( 'CloseWiki' ) ||
-		in_array( $out->mStatusCode, $statusCodesWithoutCanonicalHref )
-	) {
-		return true;
-	}
-
-	$canonicalUrl = $out->getTitle()->getFullURL();
-
-	// Allow hooks to change the canonicalUrl that will be used in the page.
-	Hooks::run( 'WikiaCanonicalHref', [ &$canonicalUrl, $out ] );
-
-	$out->addLink( [
-		'rel' => 'canonical',
-		'href' => $canonicalUrl,
-	] );
-
-	return true;
-}
+$wgHooks['BeforePageDisplay'][] = 'CanonicalHrefHooks::onBeforePageDisplay';
+$wgHooks['OutputPageAfterGetHeadLinksArray'][] = 'CanonicalHrefHooks::onOutputPageAfterGetHeadLinksArray';

--- a/extensions/wikia/CanonicalHref/CanonicalHrefHooks.php
+++ b/extensions/wikia/CanonicalHref/CanonicalHrefHooks.php
@@ -1,0 +1,50 @@
+<?php
+
+class CanonicalHrefHooks {
+	public static function onBeforePageDisplay( OutputPage $out, Skin $skin ): void {
+		$statusCodesWithoutCanonicalHref = [ 404, 410 ];
+
+		if (
+			// No canonical on pages with pagination -- they should have the link rel="next/prev" instead
+			$out->getRequest()->getVal( 'page' ) ||
+			// SUS-5546: Don't render a canonical href for the closed wiki page
+			$out->getTitle()->isSpecial( 'CloseWiki' ) ||
+			in_array( $out->mStatusCode, $statusCodesWithoutCanonicalHref )
+		) {
+			return;
+		}
+
+		$canonicalUrl = $out->getTitle()->getFullURL();
+
+		// Allow hooks to change the canonicalUrl that will be used in the page.
+		Hooks::run( 'WikiaCanonicalHref', [ &$canonicalUrl, $out ] );
+
+		$out->addLink( [
+			'rel' => 'canonical',
+			'href' => $canonicalUrl,
+		] );
+	}
+
+	/**
+	 * Strip canonical tags on pages that are noindexed as this mixes signals
+	 * to Google and they will prefer the canonical signal over the noindex.
+	 *
+	 * @param  array      &$tags
+	 * @param  OutputPage $out
+	 * @return void
+	 */
+	public static function onOutputPageAfterGetHeadLinksArray( array &$tags, OutputPage $out ): void {
+		if ( !isset( $tags['meta-robots'] ) ) {
+			return;
+		}
+
+		$robotsTag = $tags['meta-robots'];
+		if ( strpos( $robotsTag, 'content="noindex,' ) !== false ) {
+			foreach ( $tags as $i => $tag ) {
+				if ( strpos( $tag, ' rel="canonical" ' ) !== false ) {
+					unset( $tags[$i] );
+				}
+			}
+		}
+	}
+}

--- a/includes/OutputPage.php
+++ b/includes/OutputPage.php
@@ -3270,7 +3270,7 @@ $templates
 		if( $p !== 'index,follow' ) {
 			// http://www.robotstxt.org/wc/meta-user.html
 			// Only show if it's different from the default robots policy
-			$tags[] = Html::element( 'meta', array(
+			$tags['meta-robots'] = Html::element( 'meta', array(
 				'name' => 'robots',
 				'content' => $p,
 			) );
@@ -3461,6 +3461,14 @@ $templates
 				}
 			}
 		}
+
+		// Allow extensions to add, remove and/or otherwise manipulate these links
+		// If you want only to *add* <head> links, please use the addHeadItem()
+		// (or addHeadItems() for multiple items) method instead.
+		// This hook is provided as a last resort for extensions to modify these
+		// links before the output is sent to client.
+		Hooks::run( 'OutputPageAfterGetHeadLinksArray', [ &$tags, $this ] );
+
 		return implode( "\n", $tags );
 	}
 


### PR DESCRIPTION
Canonical tags on noindexed pages provides a mixed signal to Google and
they will prefer the canonical signal over the noindexed signal and spend
crawl budget on the page.

We want to remove the canonical tag on pages that include the noindex tag.
To do this, this change backports the OutputPageAfterGetHeadLinksArray hook
from newer versions of MediaWiki so the same solution may be usable on the
Unified Platform. It's not the cleanest solution, but it is something that
would work on latest MediaWiki without a core change.

/cc @Wikia/core-platform-team 