### PR TITLE
DE-4530 Add a controller which returns article data required by the recommendations service

### DIFF
--- a/includes/wikia/DefaultSettings.php
+++ b/includes/wikia/DefaultSettings.php
@@ -145,6 +145,7 @@ $wgAutoloadClasses['InfoboxApiController'] = "{$IP}/includes/wikia/api/InfoboxAp
 $wgAutoloadClasses['TemplateClassificationApiController'] = "{$IP}/includes/wikia/api/TemplateClassificationApiController.class.php";
 $wgAutoloadClasses['TemplatesApiController'] = "{$IP}/includes/wikia/api/TemplatesApiController.class.php";
 $wgAutoloadClasses['CrossWikiArticlesApiController'] = "{$IP}/includes/wikia/api/CrossWikiArticlesApiController.class.php";
+$wgAutoloadClasses['RecommendationTileApiController'] = "{$IP}/includes/wikia/api/RecommendationTileApiController.class.php";
 $wgExtensionMessagesFiles['WikiaApi'] = "{$IP}/includes/wikia/api/WikiaApi.i18n.php";
 
 $wgWikiaApiControllers['DiscoverApiController'] = "{$IP}/includes/wikia/api/DiscoverApiController.class.php";
@@ -161,6 +162,7 @@ $wgWikiaApiControllers['DWDimensionApiController'] = "{$IP}/includes/wikia/api/D
 $wgWikiaApiControllers['InfoboxApiController'] = "{$IP}/includes/wikia/api/InfoboxApiController.class.php";
 $wgWikiaApiControllers['LogEventsApiController'] = "{$IP}/includes/wikia/api/LogEventsApiController.class.php";
 $wgWikiaApiControllers['CrossWikiArticlesApiController'] = "{$IP}/includes/wikia/api/CrossWikiArticlesApiController.class.php";
+$wgWikiaApiControllers['RecommendationTileApiController'] = "{$IP}/includes/wikia/api/RecommendationTileApiController.class.php";
 
 //Wikia Api exceptions classes
 $wgAutoloadClasses[ 'ApiAccessService' ] = "{$IP}/includes/wikia/api/services/ApiAccessService.php";

--- a/includes/wikia/api/RecommendationTileApiController.class.php
+++ b/includes/wikia/api/RecommendationTileApiController.class.php
@@ -10,8 +10,6 @@ class RecommendationTileApiController extends WikiaApiController {
 	const CACHE_3_DAYS = 259200;
 
 	function getDetails() {
-		global $wgWikiaDatacenter;
-		global $wgChatPublicHost;
 		$this->setOutputFieldType( "items", self::OUTPUT_FIELD_TYPE_OBJECT );
 		$articleIds = str_getcsv( $this->request->getVal( 'ids', null ) );
 

--- a/includes/wikia/api/RecommendationTileApiController.class.php
+++ b/includes/wikia/api/RecommendationTileApiController.class.php
@@ -1,0 +1,98 @@
+<?php
+
+/**
+ * Retrieves the content of tiles displayed by the recommendations module.
+ * This controller supports a single wiki. If data regarding articles from multiple wikis is required, you should make multiple call with a modified wiki id header.
+ */
+class RecommendationTileApiController extends WikiaApiController {
+
+	const THUMBNAIL_MIN_SIZE = 400;
+	const CACHE_3_DAYS = 259200;
+
+	function getDetails() {
+		$this->setOutputFieldType( "items", self::OUTPUT_FIELD_TYPE_OBJECT );
+		$articleIds = str_getcsv( $this->request->getVal( 'ids', null ) );
+
+		$wikiId = $this->getWikiId();
+		$wikiName = $this->getWikiName();
+
+		$articles = $this->getArticleProperties( $articleIds );
+		$thumbnails = $this->getArticlesThumbnails( $articleIds, self::THUMBNAIL_MIN_SIZE, self::THUMBNAIL_MIN_SIZE );
+		$videoIds = $this->getFeaturedVideos();
+
+		$items = [];
+		/** @var Title $articleTitle */
+		foreach ( $articles as $articleTitle ) {
+			$articleId = $articleTitle->getArticleID();
+			$thumbnail = $thumbnails[$articleId];
+			$url = $articleTitle->getFullURL();
+
+			$items[$wikiId . '_' . $articleId] = [
+				// IW-2588: Force these URLs to always use HTTPS
+				// The recommendations service calls this API over HTTP, but forwards these URLs to clients
+				'url' => wfHttpsAllowedForURL( $url ) ? wfHttpToHttps( $url ) : $url,
+				'title' => $articleTitle->getPrefixedText(),
+				'wikiName' => $wikiName,
+				'thumbnail' => $thumbnail,
+				'hasVideo' => in_array( $articleId, $videoIds ),
+			];
+		}
+
+		$this->setResponseData(
+			[ 'items' => $items ],
+			null,
+			# cache for 3 days to avoid daily cache hit ratio drops - https://wikia-inc.atlassian.net/browse/DE-4346
+			static::CACHE_3_DAYS
+		);
+	}
+
+	private function getArticlesThumbnails( array $articleIds, int $width, int $height ): iterable {
+		$result = [];
+		if ( $width > 0 && $height > 0 ) {
+			$is = $this->getImageServing( $articleIds, $width, $height );
+			// only one image max is returned
+			$images = $is->getImages( 1 );
+			// parse results
+			foreach ( $articleIds as $id ) {
+				$result[ $id ] = $images[$id][0]['url'] ?? null;
+			}
+		}
+
+		return $result;
+	}
+
+	protected function getImageServing( Array $ids, int $width, int $height ): ImageServing {
+		return new ImageServing( $ids, $width, $height );
+	}
+
+	protected function getArticleProperties( Array $articles ): iterable {
+		$dbr = wfGetDB( DB_SLAVE );
+
+		$res = $dbr->select(
+			['page'],
+			'page.page_id, page_title, page_namespace',
+			['page.page_id' => $articles],
+			__METHOD__,
+			[],
+			[]
+		);
+
+		foreach ( $res as $result ) {
+			yield Title::newFromRow( $result );
+		}
+	}
+
+	protected function getWikiId(): int {
+		global $wgCityId;
+		return $wgCityId;
+	}
+
+	protected function getWikiName(): string {
+		global $wgSitename;
+		return $wgSitename;
+	}
+
+	protected function getFeaturedVideos(): Array {
+		return array_map( function( $video ) { return $video->getId(); } , ArticleVideoService::getFeaturedVideosForWiki( $this->getWikiId() ) );
+	}
+}

--- a/includes/wikia/api/RecommendationTileApiController.class.php
+++ b/includes/wikia/api/RecommendationTileApiController.class.php
@@ -36,9 +36,7 @@ class RecommendationTileApiController extends WikiaApiController {
 				'title' => $articleTitle->getPrefixedText(),
 				'wikiName' => $wikiName,
 				'thumbnail' => $thumbnail,
-				'hasVideo' => in_array( $articleId, $videoIds ),
-				'DC' => $wgWikiaDatacenter,
-				'some_config_url' => $wgChatPublicHost
+				'hasVideo' => in_array( $articleId, $videoIds )
 			];
 		}
 

--- a/includes/wikia/api/RecommendationTileApiController.class.php
+++ b/includes/wikia/api/RecommendationTileApiController.class.php
@@ -10,6 +10,7 @@ class RecommendationTileApiController extends WikiaApiController {
 	const CACHE_3_DAYS = 259200;
 
 	function getDetails() {
+		global $wgWikiaDatacenter;
 		$this->setOutputFieldType( "items", self::OUTPUT_FIELD_TYPE_OBJECT );
 		$articleIds = str_getcsv( $this->request->getVal( 'ids', null ) );
 
@@ -35,6 +36,7 @@ class RecommendationTileApiController extends WikiaApiController {
 				'wikiName' => $wikiName,
 				'thumbnail' => $thumbnail,
 				'hasVideo' => in_array( $articleId, $videoIds ),
+				'DC' => $wgWikiaDatacenter
 			];
 		}
 

--- a/includes/wikia/api/RecommendationTileApiController.class.php
+++ b/includes/wikia/api/RecommendationTileApiController.class.php
@@ -11,6 +11,7 @@ class RecommendationTileApiController extends WikiaApiController {
 
 	function getDetails() {
 		global $wgWikiaDatacenter;
+		global $wgChatPublicHost;
 		$this->setOutputFieldType( "items", self::OUTPUT_FIELD_TYPE_OBJECT );
 		$articleIds = str_getcsv( $this->request->getVal( 'ids', null ) );
 
@@ -36,7 +37,8 @@ class RecommendationTileApiController extends WikiaApiController {
 				'wikiName' => $wikiName,
 				'thumbnail' => $thumbnail,
 				'hasVideo' => in_array( $articleId, $videoIds ),
-				'DC' => $wgWikiaDatacenter
+				'DC' => $wgWikiaDatacenter,
+				'some_config_url' => $wgChatPublicHost
 			];
 		}
 

--- a/includes/wikia/api/tests/RecommedationTileApiControllerTest.php
+++ b/includes/wikia/api/tests/RecommedationTileApiControllerTest.php
@@ -1,0 +1,84 @@
+<?php
+
+use PHPUnit\Framework\TestCase;
+
+class RecommendationTileApiControllerTest extends TestCase
+{
+	protected function setUp()
+	{
+		parent::setUp();
+		require_once __DIR__ . '/../RecommendationTileApiController.class.php';
+	}
+
+	private function getTestImageIds() {
+		$ids = [1, 2];
+		$images = [];
+
+		foreach ( $ids as $id ) {
+			$images[$id] = [[
+				'url' => 'image_url_' . $id
+			]];
+		}
+
+		return $images;
+	}
+
+	private function getArticleTitles() {
+		foreach ( [1, 8] as $id ) {
+			$t = new Title();
+			$t->mNamespace = 0;
+			$t->mArticleID = $id;
+			$t->mUrlform = 'article_url';
+			$t->mTextform = 'title_' . $id;
+			yield $t;
+		}
+	}
+
+	public function testRecommendationTileShouldReturnTheSameNumberOfValuesAsRequested()
+	{
+		// mocks
+		$imageServingStub = $this->getMockBuilder( ImageServing::class )->setMethods( ['getImages'] )->getMock();
+		$imageServingStub->method( 'getImages' )->willReturn( $this->getTestImageIds() );
+
+		// object under test
+		$objectUnderTest = $this
+			->getMockBuilder( RecommendationTileApiController::class )
+			->setMethods( ['getImageServing', 'getArticleProperties', 'getWikiId', 'getWikiName', 'getFeaturedVideos'] )
+			->getMock();
+		$objectUnderTest->method( 'getImageServing' )->willReturn( $imageServingStub );
+		$objectUnderTest->method( 'getArticleProperties' )->willReturn( $this->getArticleTitles() );
+		$objectUnderTest->method( 'getWikiId' )->willReturn( 123 );
+		$objectUnderTest->method( 'getWikiName' )->willReturn( 'test_wiki_name' );
+		$objectUnderTest->method( 'getFeaturedVideos' )->willReturn( [1, 2, 3, 4] );
+
+		// given
+		$requestedIds = '1,8';
+
+		$request = new WikiaRequest( [
+			WikisApiController::PARAMETER_WIKI_IDS => $requestedIds
+		] );
+		$response = new WikiaResponse( WikiaResponse::FORMAT_JSON, $request );
+
+		$objectUnderTest->setRequest( $request );
+		$objectUnderTest->setResponse( $response );
+
+		// when
+		$objectUnderTest->getDetails();
+
+		// then
+		$responseItems = $response->getVal( 'items' );
+		$responseItems = (array)$responseItems;
+
+		$first = $responseItems['123_1'];
+		$this->assertEquals( 'title 1', $first['title'] );
+		$this->assertEquals( 'test_wiki_name', $first['wikiName'] );
+		$this->assertEquals( 'image_url_1', $first['thumbnail'] );
+		$this->assertEquals( true, $first['hasVideo'] );
+
+		$second = $responseItems['123_8'];
+		$this->assertEquals( 'title 8', $second['title'] );
+		$this->assertEquals( 'test_wiki_name', $second['wikiName'] );
+		$this->assertEquals( null, $second['thumbnail'] );
+		$this->assertEquals( false, $second['hasVideo'] );
+	}
+}


### PR DESCRIPTION
Issue
The recommendations module displays social media icons instead of nice-looking article thumbnails.

Cause
The implementation returns the first image assigned to the article instead of using the image returned by ImageServing.

Solution
Create a new endpoint which returns the article thumbnails using ImageServing directly (also the minimal picture dimensions have been set to 400x400).

In this implementation, the caller must request pictures for every wiki separately (by specifying the X-Mw-Wiki-Id header).