### PR TITLE
DE-4552 | WAM listing order is broken

### DIFF
--- a/extensions/wikia/WAM/controllers/api/WAMApiController.class.php
+++ b/extensions/wikia/WAM/controllers/api/WAMApiController.class.php
@@ -183,7 +183,7 @@ class WAMApiController extends WikiaApiController {
 		$options['wikiImageWidth'] = $this->request->getInt('wiki_image_width', self::DEFAULT_WIKI_IMAGE_WIDTH);
 		$options['wikiImageHeight'] = $this->request->getInt('wiki_image_height', WikiService::IMAGE_HEIGHT_KEEP_ASPECT_RATIO);
 		$options['sortColumn'] = $this->request->getVal('sort_column', 'wam_rank');
-		$options['sortDirection'] = $this->request->getVal('sort_direction', 'DESC');
+		$options['sortDirection'] = $this->request->getVal('sort_direction', 'ASC');
 		$options['offset'] = $this->request->getInt('offset', 0);
 		$options['limit'] = $this->request->getInt('limit', self::DEFAULT_PAGE_SIZE);
 

--- a/extensions/wikia/WAMPage/models/WAMPageModel.class.php
+++ b/extensions/wikia/WAMPage/models/WAMPageModel.class.php
@@ -291,7 +291,7 @@ class WAMPageModel extends WikiaModel {
 			'fetch_admins' => true,
 			'limit' => $iItemsPerPage,
 			'offset' => $iOffset,
-			'sort_column' => 'wam_change',
+			'sort_column' => 'wam_rank',
 			'sort_direction' => 'DESC',
 			'wiki_word' => isset( $aParams['searchPhrase'] ) ? $aParams['searchPhrase'] : null,
 			'vertical_id' => isset( $aParams['verticalId'] ) ? $aParams['verticalId'] : null,

--- a/extensions/wikia/WAMPage/models/WAMPageModel.class.php
+++ b/extensions/wikia/WAMPage/models/WAMPageModel.class.php
@@ -291,7 +291,7 @@ class WAMPageModel extends WikiaModel {
 			'fetch_admins' => true,
 			'limit' => $iItemsPerPage,
 			'offset' => $iOffset,
-			'sort_column' => 'wam_index',
+			'sort_column' => 'wam_rank',
 			'sort_direction' => 'DESC',
 			'wiki_word' => isset( $aParams['searchPhrase'] ) ? $aParams['searchPhrase'] : null,
 			'vertical_id' => isset( $aParams['verticalId'] ) ? $aParams['verticalId'] : null,

--- a/extensions/wikia/WAMPage/models/WAMPageModel.class.php
+++ b/extensions/wikia/WAMPage/models/WAMPageModel.class.php
@@ -291,7 +291,7 @@ class WAMPageModel extends WikiaModel {
 			'fetch_admins' => true,
 			'limit' => $iItemsPerPage,
 			'offset' => $iOffset,
-			'sort_column' => 'wam_rank',
+			'sort_column' => 'wam_change',
 			'sort_direction' => 'DESC',
 			'wiki_word' => isset( $aParams['searchPhrase'] ) ? $aParams['searchPhrase'] : null,
 			'vertical_id' => isset( $aParams['verticalId'] ) ? $aParams['verticalId'] : null,

--- a/extensions/wikia/WAMPage/models/WAMPageModel.class.php
+++ b/extensions/wikia/WAMPage/models/WAMPageModel.class.php
@@ -292,7 +292,7 @@ class WAMPageModel extends WikiaModel {
 			'limit' => $iItemsPerPage,
 			'offset' => $iOffset,
 			'sort_column' => 'wam_rank',
-			'sort_direction' => 'DESC',
+			'sort_direction' => 'ASC',
 			'wiki_word' => isset( $aParams['searchPhrase'] ) ? $aParams['searchPhrase'] : null,
 			'vertical_id' => isset( $aParams['verticalId'] ) ? $aParams['verticalId'] : null,
 			'wiki_lang' =>  isset( $aParams['langCode'] ) ? $aParams['langCode'] : null,

--- a/extensions/wikia/WAMPage/models/WAMPageModel.class.php
+++ b/extensions/wikia/WAMPage/models/WAMPageModel.class.php
@@ -78,7 +78,7 @@ class WAMPageModel extends WikiaModel {
 			'vertical_id' => intval( $iVerticalId ),
 			'sort_column' => 'wam_change',
 			'limit' => $this->getVisualizationItemsCount(),
-			'sort_direction' => 'DESC',
+			'sort_direction' => 'ASC',
 			'wiki_image_height' => self::VISUALIZATION_ITEM_IMAGE_HEIGHT,
 			'wiki_image_width' => self::VISUALIZATION_ITEM_IMAGE_WIDTH,
 			'fetch_wiki_images' => true,

--- a/extensions/wikia/WAMPage/models/WAMPageModel.class.php
+++ b/extensions/wikia/WAMPage/models/WAMPageModel.class.php
@@ -291,7 +291,7 @@ class WAMPageModel extends WikiaModel {
 			'fetch_admins' => true,
 			'limit' => $iItemsPerPage,
 			'offset' => $iOffset,
-			'sort_column' => 'wam_rank',
+			'sort_column' => 'wam_index',
 			'sort_direction' => 'DESC',
 			'wiki_word' => isset( $aParams['searchPhrase'] ) ? $aParams['searchPhrase'] : null,
 			'vertical_id' => isset( $aParams['verticalId'] ) ? $aParams['verticalId'] : null,

--- a/includes/wikia/services/WAMService.class.php
+++ b/includes/wikia/services/WAMService.class.php
@@ -307,11 +307,13 @@ class WAMService {
 
 		switch ($inputOptions['sortColumn']) {
 			case 'wam_rank':
-			default:
-				$options['ORDER BY'] = 'wam ' . $sortDirection;
+				$options['ORDER BY'] = 'wam_rank ' . $sortDirection;
 				break;
 			case 'wam_change':
 				$options['ORDER BY'] = 'wam_change ' . $sortDirection;
+				break;
+			default:
+				$options['ORDER BY'] = 'wam ' . $sortDirection;
 				break;
 		}
 


### PR DESCRIPTION
**Problem**
On 2019-10-23 the bug on the WAM page appeared. Listing order was broken (..., 6, 7, 9, 8, 10, 11, ...)

**Cause**
The cause of that strange order was that the same WAM score was calculated for two wikias. It came out that listing on the WAM page is based on wam_score, not wam_rank. Since wam_score was the same, wikia with lower ID was showed higher.

**Fix**
WAM Service was enriched with sorting by wam_rank and this was applied in WAMPageModel.