### PR TITLE
IW-2653 | Point to localized explore pages from non-EN global footer

### DIFF
--- a/includes/wikia/models/DesignSystemGlobalFooterModelV2.class.php
+++ b/includes/wikia/models/DesignSystemGlobalFooterModelV2.class.php
@@ -247,7 +247,7 @@ class DesignSystemGlobalFooterModelV2 extends WikiaModel {
 							'type' => 'text',
 							'value' => 'Fandom'
 						],
-						'href' => 'https://www.fandom.com/',
+						'href' => $this->getHref( 'fandom-logo' ),
 						'tracking_label' => 'explore.fandom',
 					],
 					[


### PR DESCRIPTION
During the rollout of the revamped global footer, the link to fandom.com under the Explore Properties section was changed to always point to www.fandom.com regardless of language. This PR changes it to use the localized href (also used for the Fandom logo link in the footer), which correctly points to localized explore pages on fandom.com for our supported languages.

https://wikia-inc.atlassian.net/browse/IW-2653