### PR TITLE
disclaimer-theming | Add dark background theme color

### DIFF
--- a/extensions/wikia/WatchShow/WatchShowService.class.php
+++ b/extensions/wikia/WatchShow/WatchShowService.class.php
@@ -6,8 +6,8 @@ class WatchShowService extends WikiaService {
 		       $wgWatchShowCTA,
 		       $wgWatchShowButtonLabel,
 		       $wgWatchShowCTACA,
-			   $wgWatchShowButtonLabelCA,
-			   $wgWatchShowImageURL,
+		       $wgWatchShowButtonLabelCA,
+		       $wgWatchShowImageURL,
 		       $wgWatchShowTrackingPixelURL;
 
 		$this->response->setValues( [

--- a/extensions/wikia/WatchShow/WatchShowService.class.php
+++ b/extensions/wikia/WatchShow/WatchShowService.class.php
@@ -7,8 +7,8 @@ class WatchShowService extends WikiaService {
 		       $wgWatchShowButtonLabel,
 		       $wgWatchShowCTACA,
 		       $wgWatchShowButtonLabelCA,
-			   $wgWatchShowImageURL,
-			   $wgWatchShowImageURLMobileDarkTheme,
+		       $wgWatchShowImageURL,
+		       $wgWatchShowImageURLMobileDarkTheme,
 		       $wgWatchShowTrackingPixelURL;
 
 		$this->response->setValues( [

--- a/extensions/wikia/WatchShow/WatchShowService.class.php
+++ b/extensions/wikia/WatchShow/WatchShowService.class.php
@@ -8,7 +8,6 @@ class WatchShowService extends WikiaService {
 		       $wgWatchShowCTACA,
 			   $wgWatchShowButtonLabelCA,
 			   $wgWatchShowImageURL,
-			   $wgWatchShowImageURLDarkTheme,
 		       $wgWatchShowTrackingPixelURL;
 
 		$this->response->setValues( [
@@ -18,7 +17,6 @@ class WatchShowService extends WikiaService {
 			'callToActionCA' => $wgWatchShowCTACA,
 			'buttonLabelCA' => $wgWatchShowButtonLabelCA,
 			'imageURL' => $wgWatchShowImageURL,
-			'imageURLDarkTheme' => $wgWatchShowImageURLDarkTheme,
 			'trackingPixelURL' => $wgWatchShowTrackingPixelURL,
 		] );
 	}

--- a/extensions/wikia/WatchShow/WatchShowService.class.php
+++ b/extensions/wikia/WatchShow/WatchShowService.class.php
@@ -17,7 +17,8 @@ class WatchShowService extends WikiaService {
 			'buttonLabel' => $wgWatchShowButtonLabel,
 			'callToActionCA' => $wgWatchShowCTACA,
 			'buttonLabelCA' => $wgWatchShowButtonLabelCA,
-			'imageURL' => SassUtil::isThemeDark() ? $wgWatchShowImageURLDarkTheme : $wgWatchShowImageURL,
+			// TODO:: Replace string with $wgWatchShowImageURLDarkTheme variable once set in Wiki Factory
+			'imageURL' => SassUtil::isThemeDark() ? "https://static.wikia.nocookie.net/1d8d22a4-207e-47eb-991e-2d1a1c37f1cf" : $wgWatchShowImageURL,
 			'trackingPixelURL' => $wgWatchShowTrackingPixelURL,
 		] );
 	}

--- a/extensions/wikia/WatchShow/WatchShowService.class.php
+++ b/extensions/wikia/WatchShow/WatchShowService.class.php
@@ -2,14 +2,14 @@
 
 class WatchShowService extends WikiaService {
 	public function index() {
-		global 	$wgWatchShowURL,
-				$wgWatchShowCTA,
-				$wgWatchShowButtonLabel,
-				$wgWatchShowCTACA,
-				$wgWatchShowButtonLabelCA,
-				$wgWatchShowImageURL,
-				$wgWatchShowImageURLMobileDarkTheme,
-				$wgWatchShowTrackingPixelURL;
+		global $wgWatchShowURL,
+		       $wgWatchShowCTA,
+		       $wgWatchShowButtonLabel,
+		       $wgWatchShowCTACA,
+		       $wgWatchShowButtonLabelCA,
+			   $wgWatchShowImageURL,
+			   $wgWatchShowImageURLMobileDarkTheme,
+		       $wgWatchShowTrackingPixelURL;
 
 		$this->response->setValues( [
 			'url' => $wgWatchShowURL,

--- a/extensions/wikia/WatchShow/WatchShowService.class.php
+++ b/extensions/wikia/WatchShow/WatchShowService.class.php
@@ -7,9 +7,9 @@ class WatchShowService extends WikiaService {
 		       $wgWatchShowButtonLabel,
 		       $wgWatchShowCTACA,
 		       $wgWatchShowButtonLabelCA,
-		       $wgWatchShowImageURL,
-			   $wgWatchShowTrackingPixelURL
-			   $wgWatchShowImageURLMobileDarkTheme;
+			   $wgWatchShowImageURL,
+			   $wgWatchShowImageURLMobileDarkTheme,
+		       $wgWatchShowTrackingPixelURL;
 
 		$this->response->setValues( [
 			'url' => $wgWatchShowURL,

--- a/extensions/wikia/WatchShow/WatchShowService.class.php
+++ b/extensions/wikia/WatchShow/WatchShowService.class.php
@@ -8,7 +8,7 @@ class WatchShowService extends WikiaService {
 		       $wgWatchShowCTACA,
 		       $wgWatchShowButtonLabelCA,
 			   $wgWatchShowImageURL,
-			   $wgWatchShowImageURLDarkTheme,
+			   $wgWatchShowImageURLMobileDarkTheme,
 		       $wgWatchShowTrackingPixelURL;
 
 		$this->response->setValues( [
@@ -17,8 +17,8 @@ class WatchShowService extends WikiaService {
 			'buttonLabel' => $wgWatchShowButtonLabel,
 			'callToActionCA' => $wgWatchShowCTACA,
 			'buttonLabelCA' => $wgWatchShowButtonLabelCA,
-			// TODO:: Replace string with $wgWatchShowImageURLDarkTheme variable once set in Wiki Factory
-			'imageURL' => SassUtil::isThemeDark() ? "https://static.wikia.nocookie.net/1d8d22a4-207e-47eb-991e-2d1a1c37f1cf" : $wgWatchShowImageURL,
+			// TODO:: Replace $wgWatchShowImageURLMobileDarkTheme with $wgWatchShowImageURLDarkTheme variable once set in Wiki Factory
+			'imageURL' => SassUtil::isThemeDark() ? $wgWatchShowImageURLMobileDarkTheme : $wgWatchShowImageURL,
 			'trackingPixelURL' => $wgWatchShowTrackingPixelURL,
 		] );
 	}

--- a/extensions/wikia/WatchShow/WatchShowService.class.php
+++ b/extensions/wikia/WatchShow/WatchShowService.class.php
@@ -2,14 +2,14 @@
 
 class WatchShowService extends WikiaService {
 	public function index() {
-		global $wgWatchShowURL,
-		       $wgWatchShowCTA,
-		       $wgWatchShowButtonLabel,
-		       $wgWatchShowCTACA,
-		       $wgWatchShowButtonLabelCA,
-			   $wgWatchShowImageURL,
-			   $wgWatchShowImageURLMobileDarkTheme,
-		       $wgWatchShowTrackingPixelURL;
+		global 	$wgWatchShowURL,
+				$wgWatchShowCTA,
+				$wgWatchShowButtonLabel,
+				$wgWatchShowCTACA,
+				$wgWatchShowButtonLabelCA,
+				$wgWatchShowImageURL,
+				$wgWatchShowImageURLMobileDarkTheme,
+				$wgWatchShowTrackingPixelURL;
 
 		$this->response->setValues( [
 			'url' => $wgWatchShowURL,

--- a/extensions/wikia/WatchShow/WatchShowService.class.php
+++ b/extensions/wikia/WatchShow/WatchShowService.class.php
@@ -7,7 +7,8 @@ class WatchShowService extends WikiaService {
 		       $wgWatchShowButtonLabel,
 		       $wgWatchShowCTACA,
 		       $wgWatchShowButtonLabelCA,
-		       $wgWatchShowImageURL,
+			   $wgWatchShowImageURL,
+			   $wgWatchShowImageURLDarkTheme,
 		       $wgWatchShowTrackingPixelURL;
 
 		$this->response->setValues( [
@@ -17,6 +18,7 @@ class WatchShowService extends WikiaService {
 			'callToActionCA' => $wgWatchShowCTACA,
 			'buttonLabelCA' => $wgWatchShowButtonLabelCA,
 			'imageURL' => $wgWatchShowImageURL,
+			'imageURLDarkTheme' => $wgWatchShowImageURLDarkTheme,
 			'trackingPixelURL' => $wgWatchShowTrackingPixelURL,
 		] );
 	}

--- a/extensions/wikia/WatchShow/WatchShowService.class.php
+++ b/extensions/wikia/WatchShow/WatchShowService.class.php
@@ -7,9 +7,9 @@ class WatchShowService extends WikiaService {
 		       $wgWatchShowButtonLabel,
 		       $wgWatchShowCTACA,
 		       $wgWatchShowButtonLabelCA,
-			   $wgWatchShowImageURL,
-			   $wgWatchShowImageURLMobileDarkTheme,
-		       $wgWatchShowTrackingPixelURL;
+		       $wgWatchShowImageURL,
+			   $wgWatchShowTrackingPixelURL
+			   $wgWatchShowImageURLMobileDarkTheme;
 
 		$this->response->setValues( [
 			'url' => $wgWatchShowURL,

--- a/extensions/wikia/WatchShow/WatchShowService.class.php
+++ b/extensions/wikia/WatchShow/WatchShowService.class.php
@@ -6,7 +6,7 @@ class WatchShowService extends WikiaService {
 		       $wgWatchShowCTA,
 		       $wgWatchShowButtonLabel,
 		       $wgWatchShowCTACA,
-		       $wgWatchShowButtonLabelCA,
+			   $wgWatchShowButtonLabelCA,
 			   $wgWatchShowImageURL,
 			   $wgWatchShowImageURLDarkTheme,
 		       $wgWatchShowTrackingPixelURL;

--- a/extensions/wikia/WatchShow/WatchShowService.class.php
+++ b/extensions/wikia/WatchShow/WatchShowService.class.php
@@ -7,7 +7,8 @@ class WatchShowService extends WikiaService {
 		       $wgWatchShowButtonLabel,
 		       $wgWatchShowCTACA,
 		       $wgWatchShowButtonLabelCA,
-		       $wgWatchShowImageURL,
+			   $wgWatchShowImageURL,
+			   $wgWatchShowImageURLDarkTheme,
 		       $wgWatchShowTrackingPixelURL;
 
 		$this->response->setValues( [
@@ -16,7 +17,7 @@ class WatchShowService extends WikiaService {
 			'buttonLabel' => $wgWatchShowButtonLabel,
 			'callToActionCA' => $wgWatchShowCTACA,
 			'buttonLabelCA' => $wgWatchShowButtonLabelCA,
-			'imageURL' => $wgWatchShowImageURL,
+			'imageURL' => SassUtil::isThemeDark() ? $wgWatchShowImageURLDarkTheme : $wgWatchShowImageURL,
 			'trackingPixelURL' => $wgWatchShowTrackingPixelURL,
 		] );
 	}

--- a/extensions/wikia/WatchShow/styles/index.scss
+++ b/extensions/wikia/WatchShow/styles/index.scss
@@ -1,4 +1,5 @@
 @import 'skins/shared/mixins/flexbox';
+@import "skins/shared/color";
 @import 'extensions/wikia/DesignSystem/node_modules/design-system/dist/scss/wds-variables/index';
 
 .watch-show {

--- a/extensions/wikia/WatchShow/styles/index.scss
+++ b/extensions/wikia/WatchShow/styles/index.scss
@@ -9,6 +9,12 @@
 		margin-right: 18px;
 	}
 
+	.WikiaRail &.rail-module &__cta-header {
+		font-family: "Helvetica Neue", Helvetica, Arial, sans-serif !important;
+		font-size: $wds-font-size-base !important;
+		text-align: left !important;
+	}
+
 	&__content {
 		@include align-items(center);
 		@include flexbox();
@@ -24,12 +30,6 @@
 		margin-bottom: 20px;
 		padding: 10px;
 		position: relative;
-	}
-
-	&__cta-header {
-		font-family: "Helvetica Neue", Helvetica, Arial, sans-serif !important;
-		font-size: $wds-font-size-base !important;
-		text-align: left !important;
 	}
 
 	&__image {

--- a/extensions/wikia/WatchShow/styles/index.scss
+++ b/extensions/wikia/WatchShow/styles/index.scss
@@ -15,7 +15,7 @@
 	}
 
 	&__disclaimer-message {
-		background-color: rgba($color-page, .1);
+		background-color: rgba($color-body, .1);
 		color: $color-page;
 		font-size: 8px;
 		font-style: italic;

--- a/extensions/wikia/WatchShow/styles/index.scss
+++ b/extensions/wikia/WatchShow/styles/index.scss
@@ -26,6 +26,12 @@
 		position: relative;
 	}
 
+	&__cta-header {
+		font-family: "Helvetica Neue", Helvetica, Arial, sans-serif !important;
+		font-size: $wds-font-size-base !important;
+		text-align: left !important;
+	}
+
 	&__image {
 		max-width: 100%;
 		max-height: 37px;

--- a/extensions/wikia/WatchShow/styles/index.scss
+++ b/extensions/wikia/WatchShow/styles/index.scss
@@ -15,7 +15,7 @@
 
 	&__disclaimer-message {
 		background-color: rgba($wds-color-body, .1);
-		color: $wds-fandom-color-body;
+		color: $wds-color-body;
 		font-size: 8px;
 		font-style: italic;
 		letter-spacing: .02px;

--- a/extensions/wikia/WatchShow/styles/index.scss
+++ b/extensions/wikia/WatchShow/styles/index.scss
@@ -15,6 +15,11 @@
 
 	&__disclaimer-message {
 		background-color: rgba($wds-fandom-color-black, .1);
+
+		@if $is-dark-wiki {
+			background-color: rgba($wds-color-white, .4);
+		}
+		
 		color: $wds-fandom-color-black;
 		font-size: 8px;
 		font-style: italic;

--- a/extensions/wikia/WatchShow/styles/index.scss
+++ b/extensions/wikia/WatchShow/styles/index.scss
@@ -14,13 +14,8 @@
 	}
 
 	&__disclaimer-message {
-		background-color: rgba($wds-fandom-color-black, .1);
-
-		@if $is-dark-wiki {
-			background-color: rgba($wds-color-white, .4);
-		}
-		
-		color: $wds-fandom-color-black;
+		background-color: rgba($wds-color-body, .1);
+		color: $wds-fandom-color-body;
 		font-size: 8px;
 		font-style: italic;
 		letter-spacing: .02px;

--- a/extensions/wikia/WatchShow/styles/index.scss
+++ b/extensions/wikia/WatchShow/styles/index.scss
@@ -10,6 +10,7 @@
 	}
 
 	.WikiaRail &.rail-module &__cta-header {
+		// overrides user front styles
 		font-family: "Helvetica Neue", Helvetica, Arial, sans-serif !important;
 		font-size: $wds-font-size-base !important;
 		text-align: left !important;

--- a/extensions/wikia/WatchShow/styles/index.scss
+++ b/extensions/wikia/WatchShow/styles/index.scss
@@ -15,8 +15,8 @@
 	}
 
 	&__disclaimer-message {
-		background-color: rgba($color-body, .1);
-		color: $color-body;
+		background-color: rgba($color-text, .1);
+		color: $color-text;
 		font-size: 8px;
 		font-style: italic;
 		letter-spacing: .02px;

--- a/extensions/wikia/WatchShow/styles/index.scss
+++ b/extensions/wikia/WatchShow/styles/index.scss
@@ -15,8 +15,8 @@
 	}
 
 	&__disclaimer-message {
-		background-color: rgba($color-text, .1);
-		color: $color-text;
+		background-color: rgba($color-body, .1);
+		color: $color-body;
 		font-size: 8px;
 		font-style: italic;
 		letter-spacing: .02px;

--- a/extensions/wikia/WatchShow/styles/index.scss
+++ b/extensions/wikia/WatchShow/styles/index.scss
@@ -14,8 +14,8 @@
 	}
 
 	&__disclaimer-message {
-		background-color: rgba($wds-color-body, .1);
-		color: $wds-color-body;
+		background-color: rgba($color-body, .1);
+		color: $color-body;
 		font-size: 8px;
 		font-style: italic;
 		letter-spacing: .02px;

--- a/extensions/wikia/WatchShow/styles/index.scss
+++ b/extensions/wikia/WatchShow/styles/index.scss
@@ -15,8 +15,8 @@
 	}
 
 	&__disclaimer-message {
-		background-color: rgba($color-body, .1);
-		color: $color-page;
+		background-color: rgba($color-text, .1);
+		color: $color-text;
 		font-size: 8px;
 		font-style: italic;
 		letter-spacing: .02px;

--- a/extensions/wikia/WatchShow/styles/index.scss
+++ b/extensions/wikia/WatchShow/styles/index.scss
@@ -15,8 +15,8 @@
 	}
 
 	&__disclaimer-message {
-		background-color: rgba($color-body, .1);
-		color: $color-body;
+		background-color: rgba($color-page, .1);
+		color: $color-page;
 		font-size: 8px;
 		font-style: italic;
 		letter-spacing: .02px;

--- a/extensions/wikia/WatchShow/styles/index.scss
+++ b/extensions/wikia/WatchShow/styles/index.scss
@@ -1,5 +1,5 @@
-@import 'skins/shared/mixins/flexbox';
 @import "skins/shared/color";
+@import 'skins/shared/mixins/flexbox';
 @import 'extensions/wikia/DesignSystem/node_modules/design-system/dist/scss/wds-variables/index';
 
 .watch-show {
@@ -10,7 +10,7 @@
 	}
 
 	.WikiaRail &.rail-module &__cta-header {
-		// overrides user front styles
+		// overrides user font styles
 		font-family: "Helvetica Neue", Helvetica, Arial, sans-serif !important;
 		font-size: $wds-font-size-base !important;
 		text-align: left !important;

--- a/extensions/wikia/WatchShow/templates/WatchShow_index.php
+++ b/extensions/wikia/WatchShow/templates/WatchShow_index.php
@@ -1,5 +1,5 @@
 <section class="rail-module watch-show wds-is-hidden" id="watch-show-rail-module" data-tracking-pixel="<?= $trackingPixelURL ?>">
-	<p class="watch-show__disclaimer-message">Disclosure: Some of the links below are affiliate links meaning, at no additional cost to you, Fandom will earn a commission if you click through and make a purchase</p>
+	<p class="watch-show__disclaimer-message">Some of the links below are affiliate links meaning, at no additional cost to you, Fandom will earn a commission if you click through and make a purchase</p>
 	<h2 class="watch-show__cta-header"><?= $callToAction ?></h2>
 	<div class="watch-show__content">
 		<a href="<?= $url ?>" class="wds-button wds-is-secondary" target="_blank" rel="noopener sponsored"><?= $buttonLabel ?></a>
@@ -7,7 +7,7 @@
 	</div>
 </section>
 <section class="rail-module watch-show wds-is-hidden" id="watch-show-rail-module-ca" data-tracking-pixel="<?= $trackingPixelURL ?>">
-	<p class="watch-show__disclaimer-message">Disclosure: Some of the links below are affiliate links meaning, at no additional cost to you, Fandom will earn a commission if you click through and make a purchase</p>
+	<p class="watch-show__disclaimer-message">Some of the links below are affiliate links meaning, at no additional cost to you, Fandom will earn a commission if you click through and make a purchase</p>
 	<h2 class="watch-show__cta-header"><?= $callToActionCA ?></h2>
 	<div class="watch-show__content">
 		<a href="<?= $url ?>" class="wds-button wds-is-secondary" target="_blank" rel="noopener sponsored"><?= $buttonLabelCA ?></a>

--- a/extensions/wikia/WatchShow/templates/WatchShow_index.php
+++ b/extensions/wikia/WatchShow/templates/WatchShow_index.php
@@ -1,5 +1,5 @@
 <section class="rail-module watch-show wds-is-hidden" id="watch-show-rail-module" data-tracking-pixel="<?= $trackingPixelURL ?>">
-	<p class="watch-show__disclaimer-message">Some of the links below are affiliate links meaning, at no additional cost to you, Fandom will earn a commission if you click through and make a purchase</p>
+	<p class="watch-show__disclaimer-message">Some of the links below are affiliate links meaning, at no additional cost to you, Fandom will earn a commission if you click through and make a purchase.</p>
 	<h2 class="watch-show__cta-header"><?= $callToAction ?></h2>
 	<div class="watch-show__content">
 		<a href="<?= $url ?>" class="wds-button wds-is-secondary" target="_blank" rel="noopener sponsored"><?= $buttonLabel ?></a>
@@ -7,7 +7,7 @@
 	</div>
 </section>
 <section class="rail-module watch-show wds-is-hidden" id="watch-show-rail-module-ca" data-tracking-pixel="<?= $trackingPixelURL ?>">
-	<p class="watch-show__disclaimer-message">Some of the links below are affiliate links meaning, at no additional cost to you, Fandom will earn a commission if you click through and make a purchase</p>
+	<p class="watch-show__disclaimer-message">Some of the links below are affiliate links meaning, at no additional cost to you, Fandom will earn a commission if you click through and make a purchase.</p>
 	<h2 class="watch-show__cta-header"><?= $callToActionCA ?></h2>
 	<div class="watch-show__content">
 		<a href="<?= $url ?>" class="wds-button wds-is-secondary" target="_blank" rel="noopener sponsored"><?= $buttonLabelCA ?></a>

--- a/extensions/wikia/WatchShow/templates/WatchShow_index.php
+++ b/extensions/wikia/WatchShow/templates/WatchShow_index.php
@@ -1,6 +1,6 @@
 <section class="rail-module watch-show wds-is-hidden" id="watch-show-rail-module" data-tracking-pixel="<?= $trackingPixelURL ?>">
 	<p class="watch-show__disclaimer-message">Disclosure: Some of the links below are affiliate links meaning, at no additional cost to you, Fandom will earn a commission if you click through and make a purchase</p>
-	<h2><?= $callToAction ?></h2>
+	<h2 class="watch-show__cta-header"><?= $callToAction ?></h2>
 	<div class="watch-show__content">
 		<a href="<?= $url ?>" class="wds-button wds-is-secondary" target="_blank" rel="noopener sponsored"><?= $buttonLabel ?></a>
 		<img src="<?= $imageURL ?>" alt="<?= $callToAction ?>" class="watch-show__image">
@@ -8,7 +8,7 @@
 </section>
 <section class="rail-module watch-show wds-is-hidden" id="watch-show-rail-module-ca" data-tracking-pixel="<?= $trackingPixelURL ?>">
 	<p class="watch-show__disclaimer-message">Disclosure: Some of the links below are affiliate links meaning, at no additional cost to you, Fandom will earn a commission if you click through and make a purchase</p>
-	<h2><?= $callToActionCA ?></h2>
+	<h2 class="watch-show__cta-header"><?= $callToActionCA ?></h2>
 	<div class="watch-show__content">
 		<a href="<?= $url ?>" class="wds-button wds-is-secondary" target="_blank" rel="noopener sponsored"><?= $buttonLabelCA ?></a>
 		<img src="<?= $imageURL ?>" alt="<?= $callToActionCA ?>" class="watch-show__image">


### PR DESCRIPTION
This PR uses theming to display:
- imageURL
- disclaimer background and color text
- Added styles to prevent them being overridden to CTA header [CAKE-5290](https://wikia-inc.atlassian.net/secure/RapidBoard.jspa?rapidView=347&modal=detail&selectedIssue=CAKE-5290)