### PR TITLE
MAIN-19695: Fix slideshow custom IDs

### DIFF
--- a/extensions/wikia/WikiaPhotoGallery/WikiaPhotoGallery.class.php
+++ b/extensions/wikia/WikiaPhotoGallery/WikiaPhotoGallery.class.php
@@ -1154,14 +1154,12 @@ class WikiaPhotoGallery extends ImageGallery {
 		}
 
 		// wrap image slideshow inside div.slideshow
-		$attribs = Sanitizer::mergeAttributes(
-			array(
-				'class' => $class,
-				'data-hash' => $this->mData['hash'],
-				'data-crop' => $this->mCrop,
-				'id' => $id,
-			),
-			$this->mAttribs );
+		$attribs = Sanitizer::mergeAttributes( $this->mAttribs, array(
+			'class' => $class,
+			'data-hash' => $this->mData['hash'],
+			'data-crop' => $this->mCrop,
+			'id' => $id,
+		) );
 
 		// renderSlideshow for WikiaMobile
 		if ( F::app()->checkSkin( 'wikiamobile' ) ) {


### PR DESCRIPTION
## Links

* https://wikia-inc.atlassian.net/browse/MAIN-19695
* support ticket [#892689](https://fandom.zendesk.com/hc/requests/892689)

## Description

This change ensures that `.wikia-slideshow` gets the computed values for `id` (as well as `data-hash` and `data-crop`), instead of the (sanitized) tag attribute values set by the parser on `mAttribs` in the base class.

This is because, for `Sanitizer::mergeAttributes`, the second map overrides the first (bar special handling for `class`es).

Without this change, slideshow galleries for which editors specify custom IDs will not initialize properly, as `.wikia-slideshow`'s ID will be missing its expected `slideshow-` prefix.

## Reviewers

* TBD
