### PR TITLE
SER-3670 | set width for search results

### DIFF
--- a/extensions/wikia/Search/css/WikiaSearch.scss
+++ b/extensions/wikia/Search/css/WikiaSearch.scss
@@ -331,6 +331,7 @@ $form-negative-side-padding: $form-side-padding*-1;
 
 		.media-text {
 			float: left;
+			width: 100%;
 		}
 
 		h1 {


### PR DESCRIPTION
https://wikia-inc.atlassian.net/browse/SER-3670

In some cases, search results "slide under" the right rail. Setting `width` should prevent this since the result container is sized correctly.