### PR TITLE
Remove redundant MercuryApi purge logic

### DIFF
--- a/lib/Wikia/src/Purger/CeleryPurger.php
+++ b/lib/Wikia/src/Purger/CeleryPurger.php
@@ -34,10 +34,6 @@ class CeleryPurger implements TaskProducer {
 			'urls' => [],
 			'keys' => [],
 		],
-		'mercury' => [
-			'urls' => [],
-			'keys' => [],
-		],
 		'vignette' => [
 			'urls' => [],
 			'keys' => [],
@@ -54,10 +50,6 @@ class CeleryPurger implements TaskProducer {
 		foreach ( $urls as $item ) {
 			if ( isset( $wgPurgeVignetteUsingSurrogateKeys ) && VignetteRequest::isVignetteUrl( $item ) ) {
 				$this->buckets['vignette']['urls'][] = $item;
-			} elseif ( strstr( $item, 'MercuryApi' ) !== false ) {
-				$this->buckets['mercury']['urls'][] = $item;
-				// TODO: we can remove this when mercury is only using internal cache
-				$this->buckets['mediawiki']['urls'][] = $item;
 			} else {
 				$this->buckets['mediawiki']['urls'][] = $item;
 			}

--- a/lib/Wikia/tests/Purger/CeleryPurgerTest.php
+++ b/lib/Wikia/tests/Purger/CeleryPurgerTest.php
@@ -67,11 +67,9 @@ class CeleryPurgerTest extends TestCase {
 				'https://starwars.wikia.com/wiki/Darth_Vader',
 				'http://community.wikia.com/wiki/Main_Page',
 				'https://vignette.wikia.nocookie.net/cardfight/images/d/dc/Gentle_Persuasion.jpg/revision/latest?cb=20150827145148',
-				'https://random.fandom.com/wikia.php?controller=MercuryApi',
 			],
 			[
-				'mediawiki' => [ 'https://starwars.wikia.com/wiki/Darth_Vader', 'http://community.wikia.com/wiki/Main_Page', 'https://random.fandom.com/wikia.php?controller=MercuryApi', ],
-				'mercury' => [ 'https://random.fandom.com/wikia.php?controller=MercuryApi', ],
+				'mediawiki' => [ 'https://starwars.wikia.com/wiki/Darth_Vader', 'http://community.wikia.com/wiki/Main_Page', ],
 				'vignette' => [ 'https://vignette.wikia.nocookie.net/cardfight/images/d/dc/Gentle_Persuasion.jpg/revision/latest?cb=20150827145148', ],
 			]
 		];


### PR DESCRIPTION
As apps are calling MercuryApi directly, without a caching proxy,
there is no need to purge MercuryApi URLs.