### PR TITLE
SER-3682 | set block target for global blocks

### DIFF
--- a/extensions/wikia/PhalanxII/models/PhalanxUserModel.php
+++ b/extensions/wikia/PhalanxII/models/PhalanxUserModel.php
@@ -97,6 +97,11 @@ class PhalanxUserModel extends PhalanxModel {
 		$this->user->mBlock->mTimestamp = $this->block->getTimestamp();
 		$this->user->mBlock->mAddress = $this->block->getText();
 
+		// SER-3682 for exact blocks the target should always be the user
+		if ( $type === 'exact' ) {
+			$this->user->mBlock->setTarget( $this->user );
+		}
+
 		wfProfileOut( __METHOD__ );
 		return $this;
 	}


### PR DESCRIPTION
https://wikia-inc.atlassian.net/browse/SER-3682

When creating a `Block` object from Phalanx data, set its target to the blocked user.