### PR TITLE
Remove icache surrogate key purges

### DIFF
--- a/extensions/wikia/CategoryPage3/CategoryPage3Hooks.class.php
+++ b/extensions/wikia/CategoryPage3/CategoryPage3Hooks.class.php
@@ -33,8 +33,6 @@ class CategoryPage3Hooks {
 			$surrogateKey = CategoryPage3CacheHelper::getSurrogateKey( $title );
 			// CDN
 			Wikia::purgeSurrogateKey( $surrogateKey );
-			// icache
-			Wikia::purgeSurrogateKey( $surrogateKey, 'mercury' );
 		}
 
 		return true;

--- a/extensions/wikia/FilePage/FilePageHooks.class.php
+++ b/extensions/wikia/FilePage/FilePageHooks.class.php
@@ -301,7 +301,6 @@ class FilePageHooks extends WikiaObject{
 					'key' => $key,
 				] );
 				Wikia::purgeSurrogateKey( $key );
-				Wikia::purgeSurrogateKey( $key, 'mercury' );
 			}
 		}
 	}

--- a/extensions/wikia/WikiFactory/Close/close_single_wiki.php
+++ b/extensions/wikia/WikiFactory/Close/close_single_wiki.php
@@ -238,7 +238,6 @@ class CloseSingleWiki extends Maintenance {
 		WikiFactory::clearCache( $wikiId );
 
 		Wikia::purgeSurrogateKey( Wikia::wikiSurrogateKey( $wikiId ) );
-		Wikia::purgeSurrogateKey( Wikia::wikiSurrogateKey( $wikiId ), 'mercury' );
 	}
 }
 

--- a/maintenance/wikia/HttpsMigration/migrateWikiToFandom.php
+++ b/maintenance/wikia/HttpsMigration/migrateWikiToFandom.php
@@ -157,7 +157,6 @@ class MigrateWikiToFandom extends Maintenance {
 		WikiFactory::clearCache( $wikiId );
 
 		Wikia::purgeSurrogateKey( Wikia::wikiSurrogateKey( $wikiId ) );
-		Wikia::purgeSurrogateKey( Wikia::wikiSurrogateKey( $wikiId ), 'mercury' );
 
 		$dbName = WikiFactory::IDtoDB( $wikiId );
 

--- a/maintenance/wikia/HttpsMigration/migrateWikiToWikiaOrg.php
+++ b/maintenance/wikia/HttpsMigration/migrateWikiToWikiaOrg.php
@@ -157,7 +157,6 @@ class MigrateWikiToWikiaOrg extends Maintenance {
 		WikiFactory::clearCache( $wikiId );
 
 		Wikia::purgeSurrogateKey( Wikia::wikiSurrogateKey( $wikiId ) );
-		Wikia::purgeSurrogateKey( Wikia::wikiSurrogateKey( $wikiId ), 'mercury' );
 
 		$dbName = WikiFactory::IDtoDB( $wikiId );
 

--- a/maintenance/wikia/PurgeWikiCache.php
+++ b/maintenance/wikia/PurgeWikiCache.php
@@ -13,7 +13,6 @@ class PurgeWikiCache extends Maintenance {
 		WikiFactory::clearCache( $wgCityId );
 
 		Wikia::purgeSurrogateKey( Wikia::wikiSurrogateKey( $wgCityId ) );
-		Wikia::purgeSurrogateKey( Wikia::wikiSurrogateKey( $wgCityId ), 'mercury' );
 
 		$this->output( 'Cache purged!' );
 	}

--- a/maintenance/wikia/PurgeWikiCacheEverywhere.php
+++ b/maintenance/wikia/PurgeWikiCacheEverywhere.php
@@ -40,13 +40,10 @@ class PurgeWikiCacheEverywhere extends Maintenance {
 		//proxy purge
 		$this->output( 'Purge prod surrogate keys' );
 		Wikia::purgeSurrogateKey( $prodKey );
-		Wikia::purgeSurrogateKey( $prodKey, 'mercury' );
 		$this->output( 'Purge surrogate keys for preview' );
 		Wikia::purgeSurrogateKey( $previewKey );
-		Wikia::purgeSurrogateKey( $previewKey, 'mercury' );
 		$this->output( 'Purge surrogate keys for verify' );
 		Wikia::purgeSurrogateKey( $verifyKey );
-		Wikia::purgeSurrogateKey( $verifyKey, 'mercury' );
 
 		$this->output( 'Cache purged!' );
 	}


### PR DESCRIPTION
There are no more clients using icache, so there is no need to purge
surrogate keys there.