### PR TITLE
Bypass potential negative file cache entries in VideoEmbedTool

### DIFF
--- a/extensions/wikia/VideoEmbedTool/VideoEmbedTool_body.php
+++ b/extensions/wikia/VideoEmbedTool/VideoEmbedTool_body.php
@@ -302,7 +302,7 @@ class VideoEmbedTool {
 			$success = false;
 			if ( $placeholder ) {
 				$placeholder_tag = $placeholder[0];
-				$file = wfFindFile( $title );
+				$file = wfFindFile( $title, [ 'bypassCache' => true ] );
 				$embed_code = $file->transform( array( 'width'=>$width ) )->toHtml();
 
 				$params = array(


### PR DESCRIPTION
RepoGroup::findFile(), used to lookup files based on their name or title,
uses a process cache to memoize the results of lookups, including negatives
(when a file was not found). This can cause issues in file upload code that
tries to access the newly uploaded file via this method after the upload was
performed; if the file was looked up before the upload, the method will return
a false negative due to the process cache.

VideoEmbedTool::insertFinalVideo() is an example of such code. As a fix, make
sure to bypass the process cache in this method to avoid the false negative.