### PR TITLE
SER | Don't include comments in HTML output for indexer

### DIFF
--- a/extensions/wikia/Search/classes/IndexService/FullContent.php
+++ b/extensions/wikia/Search/classes/IndexService/FullContent.php
@@ -13,8 +13,6 @@ use simple_html_dom;
  * @subpackage IndexService
  */
 class FullContent extends AbstractService {
-	const SPACE_SEQUENCE_REGEXP = "/\s+/";
-
 	/**
 	 * Text from selectors in this list should be removed during HTML stripping.
 	 *
@@ -32,14 +30,8 @@ class FullContent extends AbstractService {
 		'sup.reference',
 		'script',
 		'style',
+		'comment',
 	];
-
-	/**
-	 * We remove these selectors since they are unreliable indicators of textual content
-	 *
-	 * @var array
-	 */
-	protected $asideSelectors = [ 'table', 'figure', 'div.noprint', 'div.quote', '.dablink' ];
 
 	/**
 	 * Returns the fields required to make the document searchable (specifically, wid and title and body content)


### PR DESCRIPTION
We're including parser comments in the html output of the indexer, like so:
```
 <!--  NewPP limit report Cached time: 20191204101306 Cache expiry: 86400 Dynamic content: false CPU time usage: 0.029 seconds Real time usage: 0.047 seconds Preprocessor visited node count: 1/1000000 Preprocessor generated node count: 4/1000000 Post‐expand include size: 0/2097152 bytes Template argument size: 0/2097152 bytes Highest expansion depth: 1/40 Expensive parser function count: 0/100 Unstrip recursion depth: 0/20 Unstrip post‐expand size: 0/5000000 bytes --> <!-- Transclusion expansion time report (%,ms,calls,template) 100.00%    0.000      1 -total -->  <!-- Saved in parser cache with key ucpcommunity:pcache:idhash:123-0!canonical and timestamp 20191204101306 and revision id 284  -->
```
This is not useful and slightly, but unnecessarily, slows down the indexing.