### PR TITLE
IW-2736 | Validate Wall/ForumBoard namespace on construct

### DIFF
--- a/extensions/wikia/Forum/ForumExternalController.class.php
+++ b/extensions/wikia/Forum/ForumExternalController.class.php
@@ -205,7 +205,7 @@ class ForumExternalController extends WallExternalController {
 		$board = ForumBoard::newFromId( $boardId );
 		$destinationBoard = ForumBoard::newFromId( $destinationBoardId );
 
-		if ( empty( $boardId ) || empty( $destinationBoardId ) ) {
+		if ( !$board || !$destinationBoard ) {
 			$this->status = 'error';
 			$this->errormsg = '';
 			return true;

--- a/extensions/wikia/Forum/tests/ForumBoardIntegrationTest.php
+++ b/extensions/wikia/Forum/tests/ForumBoardIntegrationTest.php
@@ -1,0 +1,56 @@
+<?php
+
+/**
+ * @group Integration
+ */
+class ForumBoardIntegrationTest extends WikiaDatabaseTest {
+	private const NOT_FORUM_BOARD_ID = 885;
+	private const VALID_FORUM_BOARD_ID = 1204;
+	private const VALID_FORUM_BOARD_PAGE = 'ValidForumBoardPage';
+
+	public static function setUpBeforeClass() {
+		parent::setUpBeforeClass();
+		require_once __DIR__ . '/../../Wall/Wall.setup.php';
+		require_once __DIR__ . '/../Forum.setup.php';
+	}
+
+
+	public function testShouldReturnNullWhenPageWithGivenIdDoesNotExist(): void {
+		$board = ForumBoard::newFromId( 256 );
+
+		$this->assertNull( $board );
+	}
+
+	public function testShouldReturnNullWhenGivenIdDoesNotBelongToForumBoardPage(): void {
+		$board = ForumBoard::newFromId( self::NOT_FORUM_BOARD_ID );
+
+		$this->assertNull( $board );
+	}
+
+	public function testShouldReturnNullWhenGivenTitleDoesNotBelongToForumBoardPage(): void {
+		$title = Title::makeTitle( NS_MAIN, 'NotForumBoardEither');
+
+		$board = ForumBoard::newFromTitle( $title );
+
+		$this->assertNull( $board );
+	}
+
+	public function testShouldCreateForumBoardBasedOnIdOfForumBoardPage(): void {
+		$board = ForumBoard::newFromId( self::VALID_FORUM_BOARD_ID );
+
+		$this->assertInstanceOf( ForumBoard::class, $board );
+		$this->assertEquals( self::VALID_FORUM_BOARD_PAGE, $board->getTitle()->getText() );
+	}
+
+	public function testShouldCreateForumBoardBasedOnTitleOfForumBoardPage(): void {
+		$title = Title::makeTitle( NS_WIKIA_FORUM_BOARD, self::VALID_FORUM_BOARD_PAGE );
+
+		$board = ForumBoard::newFromTitle( $title );
+
+		$this->assertInstanceOf( ForumBoard::class, $board );
+	}
+
+	protected function getDataSet() {
+		return $this->createYamlDataSet( __DIR__ . '/fixtures/forum.yaml' );
+	}
+}

--- a/extensions/wikia/Forum/tests/fixtures/forum.yaml
+++ b/extensions/wikia/Forum/tests/fixtures/forum.yaml
@@ -1,0 +1,15 @@
+page:
+  - page_id: 885
+    page_namespace: 0
+    page_title: NotForumBoardPage
+    page_restrictions: ''
+    page_random: 0
+    page_latest: 0
+    page_len: 0
+  - page_id: 1204
+    page_namespace: 2000
+    page_title: ValidForumBoardPage
+    page_restrictions: ''
+    page_random: 0
+    page_latest: 0
+    page_len: 0

--- a/extensions/wikia/Wall/Wall.class.php
+++ b/extensions/wikia/Wall/Wall.class.php
@@ -28,18 +28,24 @@ class Wall extends WikiaModel {
 	}
 
 	/**
+	 * Return an instance of Wall corresponding to the given title,
+	 * or null if the given title is not in a valid Wall namespace.
 	 * @param Title $title
-	 *
-	 * @return static
+	 * @return static|null
 	 */
-	static public function newFromTitle( Title $title ): Wall {
-		wfProfileIn( __METHOD__ );
+	static public function newFromTitle( Title $title ): ?Wall {
+		global $wgWallNS, $wgCityId;
 
-		$wall = new static();
-		$wall->mTitle = $title;
-		$wall->mCityId = F::app()->wg->CityId;
-		wfProfileOut( __METHOD__ );
-		return $wall;
+		// IW-2736: Ensure that the provided title belongs to a valid Wall namespace
+		if ( $title->inNamespaces( $wgWallNS ) ) {
+			$wall = new static();
+			$wall->mTitle = $title;
+			$wall->mCityId = $wgCityId;
+
+			return $wall;
+		}
+
+		return null;
 	}
 
 	/**

--- a/extensions/wikia/Wall/tests/WallIntegrationTest.php
+++ b/extensions/wikia/Wall/tests/WallIntegrationTest.php
@@ -1,0 +1,54 @@
+<?php
+
+/**
+ * @group Integration
+ */
+class WallIntegrationTest extends WikiaDatabaseTest {
+	private const NOT_WALL_ID = 885;
+	private const VALID_WALL_ID = 1204;
+	private const VALID_WALL_PAGE = 'ValidWallPage';
+
+	public static function setUpBeforeClass() {
+		parent::setUpBeforeClass();
+		require_once __DIR__ . '/../Wall.setup.php';
+	}
+
+	public function testShouldReturnNullWhenPageWithGivenIdDoesNotExist(): void {
+		$wall = Wall::newFromId( 256 );
+
+		$this->assertNull( $wall );
+	}
+
+	public function testShouldReturnNullWhenGivenIdDoesNotBelongToWallPage(): void {
+		$wall = Wall::newFromId( self::NOT_WALL_ID );
+
+		$this->assertNull( $wall );
+	}
+
+	public function testShouldReturnNullWhenGivenTitleDoesNotBelongToWallPage(): void {
+		$title = Title::makeTitle( NS_MAIN, 'NotWallEither');
+
+		$wall = Wall::newFromTitle( $title );
+
+		$this->assertNull( $wall );
+	}
+
+	public function testShouldCreateWallBasedOnIdOfWallPage(): void {
+		$wall = Wall::newFromId( self::VALID_WALL_ID );
+
+		$this->assertInstanceOf( Wall::class, $wall );
+		$this->assertEquals( self::VALID_WALL_PAGE, $wall->getTitle()->getText() );
+	}
+
+	public function testShouldCreateWallBasedOnTitleOfWallPage(): void {
+		$title = Title::makeTitle( NS_USER_WALL, self::VALID_WALL_PAGE );
+
+		$wall = Wall::newFromTitle( $title );
+
+		$this->assertInstanceOf( Wall::class, $wall );
+	}
+
+	protected function getDataSet() {
+		return $this->createYamlDataSet( __DIR__ . '/fixtures/wall.yaml' );
+	}
+}

--- a/extensions/wikia/Wall/tests/fixtures/wall.yaml
+++ b/extensions/wikia/Wall/tests/fixtures/wall.yaml
@@ -1,0 +1,15 @@
+page:
+  - page_id: 885
+    page_namespace: 0
+    page_title: NotWallPage
+    page_restrictions: ''
+    page_random: 0
+    page_latest: 0
+    page_len: 0
+  - page_id: 1204
+    page_namespace: 1200
+    page_title: ValidWallPage
+    page_restrictions: ''
+    page_random: 0
+    page_latest: 0
+    page_len: 0


### PR DESCRIPTION
Ensure that Wall/ForumBoard instances belong to a valid wall namespace
(NS_WALL/NS_WIKIA_FORUM_BOARD) when they are instantiated.

https://wikia-inc.atlassian.net/browse/IW-2736