### PR TITLE
ADEN-8567 Clean up src for ad mirrors

### DIFF
--- a/extensions/wikia/AdEngine3/src/setup.js
+++ b/extensions/wikia/AdEngine3/src/setup.js
@@ -66,9 +66,7 @@ async function setupAdContext(wikiContext, consents) {
 	context.set('custom.hiviLeaderboard', instantConfig.isGeoEnabled('wgAdDriverOasisHiviLeaderboardCountries'));
 
 	if (context.get('wiki.opts.isAdTestWiki') && context.get('wiki.targeting.testSrc')) {
-		// TODO: ADEN-8318 remove originalSrc and leave one value (testSrc)
-		const originalSrc = context.get('src');
-		context.set('src', [originalSrc, context.get('wiki.targeting.testSrc')]);
+		context.set('src', context.get('wiki.targeting.testSrc'));
 	} else if (context.get('wiki.opts.isAdTestWiki')) {
 		context.set('src', 'test');
 	}


### PR DESCRIPTION
We don't need anymore double `src` values for ad mirrors: externaltest and showcase.