### PR TITLE
Increase maxReplicas for mediawiki-tasks

### DIFF
--- a/docker/prod/prod.template.yaml
+++ b/docker/prod/prod.template.yaml
@@ -325,7 +325,7 @@ spec:
     apiVersion: apps/v1
     kind: Deployment
     name: mediawiki-tasks
-  maxReplicas: 30
+  maxReplicas: 45
   minReplicas: 15
   metrics:
   - type: Resource


### PR DESCRIPTION
A few times a day we're exhausting all mediawiki-tasks. Maximum number of replicas is reached and each fpm worker is running the maximum number of processes (20). This causes severe issues:
* false alarms when the metrics we track do not get updated for 15-30 minutes
* liveness probe starts failing on php container and k8s restarts them (interrupting the tasks in progress)

Increasing the maximum number of replicas from 30 to 45. It that does not help, we can increase it further to tweak fpm setting for mediawiki-tasks deployment.
