### PR TITLE
PLATFORM-4490: validate Helios info responses

### DIFF
--- a/includes/User.php
+++ b/includes/User.php
@@ -4307,31 +4307,7 @@ class User implements JsonSerializable {
 	public function setGlobalAuthToken( $token ) {
 		$this->globalAuthToken = $token;
 	}
-
-	/**
-	 * Is the user authenticated via the authentication service?
-	 * @return bool true if yes, false if no
-	 */
-	public function isUserAuthenticatedViaAuthenticationService() {
-		global $wgRejectAuthenticationFallback;
-
-		if ( !$wgRejectAuthenticationFallback ) {
-			return true;
-		}
-
-		$token = $this->getGlobalAuthToken();
-		if ( empty( $token ) ) {
-			return false;
-		}
-
-		$tokenInfo = self::heliosClient()->info( $token );
-		if ( !empty( $tokenInfo->user_id ) ) {
-			return ( $this->getId() > 0 ) && ( $tokenInfo->user_id == $this->getId() );
-		}
-
-		return false;
-	}
-
+	
 	/**
 	 * Get the list of explicit group memberships this user has.
 	 * The implicit * and user groups are not included.

--- a/includes/User.php
+++ b/includes/User.php
@@ -488,35 +488,9 @@ class User implements JsonSerializable {
 		}
 
 		try {
-			$tokenInfo = self::heliosClient()->info( $token );
+			$tokenInfo = self::heliosClient()->info( $token, $request );
 			if ( empty( $tokenInfo->user_id ) ) {
 				return new User;
-			}
-
-			// PLATFORM-4490 - make sure helios returns correct user id
-			$sessionUserId = $request->getSessionData( 'helios_user_id' );
-			if ( empty( $sessionUserId ) ) {
-				$request->setSessionData( 'helios_user_id', $tokenInfo->user_id );
-			} else {
-				if ( $tokenInfo->user_id != $sessionUserId ) {
-					// try to exclude false alerts when user just logged into a new account
-					if ( !empty( $_SERVER['HTTP_REFERER'] ) &&
-						 ( strpos( $_SERVER['HTTP_REFERER'], '/signin' ) !== false ||
-						   strpos( $_SERVER['HTTP_REFERER'], '/register' ) !== false ) ) {
-						$request->setSessionData( 'helios_user_id', $tokenInfo->user_id );
-					} else {
-						WikiaLogger::instance()->error( 'Helios user id mismatch', [
-							'sessionUserId' => $sessionUserId,
-							'heliosResponse' => [
-								'userId' => $tokenInfo->user_id,
-								'accessToken' => $tokenInfo->access_token,
-								'beacon' => self::heliosClient()->getResponseHeader( 'x-client-beacon-id' ),
-								'servedBy' => self::heliosClient()->getResponseHeader( 'x-served-by' ),
-								'timestamp' => self::heliosClient()->getResponseHeader( 'x-backend-timestamp' ),
-							]
-						] );
-					}
-				}
 			}
 
 			$user = self::newFromId( $tokenInfo->user_id );

--- a/lib/Wikia/src/Service/Helios/HeliosClient.php
+++ b/lib/Wikia/src/Service/Helios/HeliosClient.php
@@ -295,7 +295,7 @@ class HeliosClient {
 				 $currentCtx['client_beacon_id'] != $responseBeacon ) {
 				// report an issue with the token mismatch
 				\Wikia\Logger\WikiaLogger::instance()->error(
-					'Helios user id mismatch',
+					'Helios beacon mismatch',
 					[
 						'sessionUserId' => $sessionUserId,
 						'heliosResponse' => [

--- a/lib/Wikia/src/Service/Helios/HeliosClient.php
+++ b/lib/Wikia/src/Service/Helios/HeliosClient.php
@@ -308,7 +308,7 @@ class HeliosClient {
 					]
 				);
 
-				$tries --;
+				$tries--;
 				if ( !$tries ) {
 					// something is seriously wrong
 					throw new ClientException( "Persistent Helios beacon mismatch" );

--- a/lib/Wikia/src/Service/Helios/HeliosClient.php
+++ b/lib/Wikia/src/Service/Helios/HeliosClient.php
@@ -288,9 +288,9 @@ class HeliosClient {
 				return $tokenInfo;
 			}
 			$responseBeacon = $this->getResponseHeader( 'x-client-beacon-id' )[0];
+
 			// check if Helios returned non-matching user_id. Sometimes it means user logged into a different account
 			// so we compare beacons as well just to be sure there was a mismatch
-
 			if ( ( empty( $sessionUserId ) || $sessionUserId != $tokenInfo->user_id ) &&
 				 $currentCtx['client_beacon_id'] != $responseBeacon ) {
 				// report an issue with the token mismatch

--- a/lib/Wikia/src/Service/Helios/HeliosClient.php
+++ b/lib/Wikia/src/Service/Helios/HeliosClient.php
@@ -61,11 +61,15 @@ class HeliosClient {
 
 	/**
 	 * Returns one of the response headers with a default values as a fallback
+	 *
+	 * Because some headers can appear more than once the, this method returns
+	 * an array of the values.
+	 *
 	 * @param $header Header name
 	 * @param string $default value returned in case of missing header
-	 * @return string
+	 * @return array
 	 */
-	public function getResponseHeader( $header, $default = '' ) {
+	public function getResponseHeader( $header, $default = [''] ) {
 		$header = strtolower( $header );
 		if ( is_array( $this->responseHeaders ) && array_key_exists( $header, $this->responseHeaders ) ) {
 			return $this->responseHeaders[$header];
@@ -251,17 +255,70 @@ class HeliosClient {
 	 * A shortcut method for info requests
 	 *
 	 * @param $token
-	 *
 	 * @return mixed|null
 	 */
-	public function info( $token ) {
+	private function _info( $token ) {
+		// @todo - rename to info once PLATFORM-4490 is resolved, remove $request param from the caller
 		return $this->request(
 			'info',
 			[
-				'code'         => $token,
+				'code' => $token,
 				'noblockcheck' => 1,
 			]
 		);
+	}
+
+	/**
+	 * A shortcut method for info requests
+	 *
+	 * PLATFORM-4490 - validate Helios responses and retry in case of mismatches
+	 * this method is a wrapper for the _info call, remove it once the issue is resolved
+	 *
+	 * @param $token
+	 * @param WebRequest $request The HTTP request data as an object
+	 * @return mixed|null
+	 */
+	public function info( $token, $request ) {
+		$tries = 3;
+		$currentCtx = \Wikia\Tracer\WikiaTracer::instance()->getContext();
+		$sessionUserId = $request->getSessionData( 'helios_user_id' );
+		while ( true ) {
+			$tokenInfo = $this->_info( $token );
+			if ( empty( $tokenInfo->user_id ) ) {
+				return $tokenInfo;
+			}
+			$responseBeacon = $this->getResponseHeader( 'x-client-beacon-id' )[0];
+			// check if Helios returned non-matching user_id. Sometimes it means user logged into a different account
+			// so we compare beacons as well just to be sure there was a mismatch
+
+			if ( ( empty( $sessionUserId ) || $sessionUserId != $tokenInfo->user_id ) &&
+				 $currentCtx['client_beacon_id'] != $responseBeacon ) {
+				// report an issue with the token mismatch
+				\Wikia\Logger\WikiaLogger::instance()->error(
+					'Helios user id mismatch',
+					[
+						'sessionUserId' => $sessionUserId,
+						'heliosResponse' => [
+							'userId' => $tokenInfo->user_id,
+							'accessToken' => $tokenInfo->access_token,
+							'beacon' => $responseBeacon,
+							'servedBy' => $this->getResponseHeader( 'x-served-by' )[0],
+							'timestamp' => $this->getResponseHeader( 'x-backend-timestamp' )[0],
+						],
+					]
+				);
+
+				$tries --;
+				if ( !$tries ) {
+					// something is seriously wrong
+					throw new ClientException( "Persistent Helios beacon mismatch" );
+				}
+			} else {
+				// correct Helios response, store user id for future checks
+				$request->setSessionData( 'helios_user_id', $tokenInfo->user_id );
+				return $tokenInfo;
+			}
+		}
 	}
 
 	/**


### PR DESCRIPTION
* Move the error detection from the `User` class to `HeliosClient`
* reduce false positives by comparing beacon as well
* in case of a mismatch - retry
* rename the original method to `_info` so we can roll it back easily once not needed