### PR TITLE
CAKE-5464 | Create privacy update banner notification

### DIFF
--- a/extensions/wikia/AssetsManager/config.php
+++ b/extensions/wikia/AssetsManager/config.php
@@ -183,7 +183,7 @@ $config['oasis_jquery'] = [
 		// jQuery/Oasis specific code
 		'//skins/oasis/js/tables.js',
 
-		// Remove this code after one week to display privacy notice update
+		// To be removed in https://wikia-inc.atlassian.net/browse/CAKE-5470
 		'//skins/oasis/js/privacyUpdateNotification.js',
 
 		// BackgroundChanger

--- a/extensions/wikia/AssetsManager/config.php
+++ b/extensions/wikia/AssetsManager/config.php
@@ -183,6 +183,9 @@ $config['oasis_jquery'] = [
 		// jQuery/Oasis specific code
 		'//skins/oasis/js/tables.js',
 
+		// Remove this code after one week to display privacy notice update
+		'//skins/oasis/js/privacyUpdateNotification.js',
+
 		// BackgroundChanger
 		'//skins/oasis/js/BackgroundChanger.js',
 

--- a/skins/oasis/js/privacyUpdateNotification.js
+++ b/skins/oasis/js/privacyUpdateNotification.js
@@ -13,7 +13,7 @@ $(function() {
     }
 
     if (!getCookie('dismissed-privacy-notification')) {
-        var message = 'Please take notice that we have updated our <a href="www.fandom.com/privacy-policy">privacy policy</a>, <a href="www.fandom.com/terms-of-use">terms of use</a> and <a href="www.fandom.com/terms-of-sale">terms of sale</a> to (a) provide greater transparency around the ways we collect, process, and use personal information, and to implement the requirements of the California Consumer Privacy Act (CCPA), and (b) to create a single privacy policy, terms of use and terms of sale across all of our properties. These changes went into effect on January 1, 2020.';
+        var message = 'Please take notice that we have updated our <a href="https://www.fandom.com/privacy-policy">privacy policy</a>, <a href="https://www.fandom.com/terms-of-use">terms of use</a> and <a href="https://www.fandom.com/terms-of-sale">terms of sale</a> to (a) provide greater transparency around the ways we collect, process, and use personal information, and to implement the requirements of the California Consumer Privacy Act (CCPA), and (b) to create a single privacy policy, terms of use and terms of sale across all of our properties. These changes went into effect on January 1, 2020.';
         // display notification
         new BannerNotification(message).show();
 

--- a/skins/oasis/js/privacyUpdateNotification.js
+++ b/skins/oasis/js/privacyUpdateNotification.js
@@ -5,7 +5,7 @@ $(function() {
         var notification = new BannerNotification(message).show();
 
         notification.onClose(function() {
-            document.cookie = 'dismissed-privacy-notification=true; path=/';
+            window.Wikia.Cookies.set('dismissed-privacy-notification', true);
         });
     }   
 });

--- a/skins/oasis/js/privacyUpdateNotification.js
+++ b/skins/oasis/js/privacyUpdateNotification.js
@@ -1,24 +1,10 @@
 $(function() {
-    function getCookie(name) {
-        var nameEQ = name + '=';
-        var ca = document.cookie.split(';');
-    
-        for (var i = 0; i < ca.length; i++) {
-            var c = ca[i];
-            while (c.charAt(0) === ' ') c = c.substring(1, c.length);
-            if (c.indexOf(nameEQ) === 0) return c.substring(nameEQ.length, c.length);
-        }
-    
-        return null;
-    }
-
-    if (!getCookie('dismissed-privacy-notification')) {
+    if (!window.Wikia.Cookies.get('dismissed-privacy-notification')) {
         var message = 'Please take notice that we have updated our <a href="https://www.fandom.com/privacy-policy">privacy policy</a>, <a href="https://www.fandom.com/terms-of-use">terms of use</a> and <a href="https://www.fandom.com/terms-of-sale">terms of sale</a> to (a) provide greater transparency around the ways we collect, process, and use personal information, and to implement the requirements of the California Consumer Privacy Act (CCPA), and (b) to create a single privacy policy, terms of use and terms of sale across all of our properties. These changes went into effect on January 1, 2020.';
         // display notification
-        new BannerNotification(message).show();
+        var notification = new BannerNotification(message).show();
 
-        $('.wds-banner-notification__close').on('click', function() {
-            // set cookie
+        notification.onClose(function() {
             document.cookie = 'dismissed-privacy-notification=true; path=/';
         });
     }   

--- a/skins/oasis/js/privacyUpdateNotification.js
+++ b/skins/oasis/js/privacyUpdateNotification.js
@@ -1,5 +1,4 @@
 $(function() {
-
     function getCookie(name) {
         var nameEQ = name + '=';
         var ca = document.cookie.split(';');
@@ -13,15 +12,14 @@ $(function() {
         return null;
     }
 
-    function setCookie(name) {
-        document.cookie = name + '=true; path=/';
-    }
-
     if (!getCookie('dismissed-privacy-notification')) {
-        new BannerNotification('Please take notice that we have updated our <a href="www.fandom.com/privacy-policy">privacy policy</a>, <a href="www.fandom.com/terms-of-use">terms of use</a> and <a href="www.fandom.com/terms-of-sale">terms of sale</a> to (a) provide greater transparency around the ways we collect, process, and use personal information, and to implement the requirements of the California Consumer Privacy Act (CCPA), and (b) to create a single privacy policy, terms of use and terms of sale across all of our properties. These changes went into effect on January 1, 2020.').show();
+        var message = 'Please take notice that we have updated our <a href="www.fandom.com/privacy-policy">privacy policy</a>, <a href="www.fandom.com/terms-of-use">terms of use</a> and <a href="www.fandom.com/terms-of-sale">terms of sale</a> to (a) provide greater transparency around the ways we collect, process, and use personal information, and to implement the requirements of the California Consumer Privacy Act (CCPA), and (b) to create a single privacy policy, terms of use and terms of sale across all of our properties. These changes went into effect on January 1, 2020.';
+        // display notification
+        new BannerNotification(message).show();
 
         $('.wds-banner-notification__close').on('click', function() {
-            setCookie('dismissed-privacy-notification');
+            // set cookie
+            document.cookie = 'dismissed-privacy-notification=true; path=/';
         });
     }   
 });

--- a/skins/oasis/js/privacyUpdateNotification.js
+++ b/skins/oasis/js/privacyUpdateNotification.js
@@ -1,0 +1,27 @@
+$(function() {
+
+    function getCookie(name) {
+        var nameEQ = name + '=';
+        var ca = document.cookie.split(';');
+    
+        for (var i = 0; i < ca.length; i++) {
+            var c = ca[i];
+            while (c.charAt(0) === ' ') c = c.substring(1, c.length);
+            if (c.indexOf(nameEQ) === 0) return c.substring(nameEQ.length, c.length);
+        }
+    
+        return null;
+    }
+
+    function setCookie(name) {
+        document.cookie = name + '=true; path=/';
+    }
+
+    if (!getCookie('dismissed-privacy-notification')) {
+        new BannerNotification('Please take notice that we have updated our <a href="www.fandom.com/privacy-policy">privacy policy</a>, <a href="www.fandom.com/terms-of-use">terms of use</a> and <a href="www.fandom.com/terms-of-sale">terms of sale</a> to (a) provide greater transparency around the ways we collect, process, and use personal information, and to implement the requirements of the California Consumer Privacy Act (CCPA), and (b) to create a single privacy policy, terms of use and terms of sale across all of our properties. These changes went into effect on January 1, 2020.').show();
+
+        $('.wds-banner-notification__close').on('click', function() {
+            setCookie('dismissed-privacy-notification');
+        });
+    }   
+});


### PR DESCRIPTION
Adds a banner notification to MW informing the user that the privacy policy has been updated.

Once they dismiss the notification, a cookie will be set in the browser so that the message won't be displayed again.

This notification is set to display for one week at which time, the code will need to be removed. 

Description: 

To be removed in https://wikia-inc.atlassian.net/browse/CAKE-5470