### PR TITLE
Kill about 10% of old pods

### DIFF
--- a/docker/prod/Jenkinsfile
+++ b/docker/prod/Jenkinsfile
@@ -346,7 +346,7 @@ node("docker-daemon-big") {
                 'DATACENTER': 'sjc',
                 'APP_VERSION': nextAppTag,
                 'CONFIG_VERSION': nextConfigTag,
-                'PODS': '120'
+                'PODS': '105'
               ])
 
               sh("""cat > docker/prod/sjc.yaml <<EOL
@@ -369,7 +369,7 @@ EOL""")
                 'DATACENTER': 'res',
                 'APP_VERSION': nextAppTag,
                 'CONFIG_VERSION': nextConfigTag,
-                'PODS': '80'
+                'PODS': '70'
               ])
 
               sh("""cat > docker/prod/res.yaml <<EOL


### PR DESCRIPTION
We are about to switch prod traffic to new pods with UCP and APP repo. We are at 20% now, and this PR is about disabling about 10% of old pods to free up resources for new pods 