### PR TITLE
PLATFORM | fix undefined constant in ApiResult

### DIFF
--- a/includes/api/ApiQuery.php
+++ b/includes/api/ApiQuery.php
@@ -514,7 +514,11 @@ class ApiQuery extends ApiBase {
 			// Raw formatter will handle this
 			$result->addValue( null, 'text', $exportxml );
 			$result->addValue( null, 'mime', 'text/xml' );
-			$result->addValue( null, 'filename', 'export.xml', ApiResult::NO_SIZE_CHECK );
+
+			$result->disableSizeCheck();
+			$result->addValue( null, 'filename', 'export.xml' );
+			$result->enableSizeCheck();
+
 		} else {
 			$r = array();
 			ApiResult::setContent( $r, $exportxml );


### PR DESCRIPTION
The patch for T128209, backported in fac7ff5731cc992e59d5503e1196f45260ae7796,
references a constant that was added to the ApiResult class in 1.24,
thereby causing an error when the relevant code path is executed.

As a fix, use ApiResult::disableSizeCheck and ApiResult::enableSizeCheck
to achieve the same effect as the new constant would.