### PR TITLE
PLATFORM-4605: fixing the non-ucp path check (regression)

### DIFF
--- a/extensions/wikia/WikiFactory/SpecialWikiFactory_ajax.php
+++ b/extensions/wikia/WikiFactory/SpecialWikiFactory_ajax.php
@@ -527,7 +527,7 @@ function axWFactoryDomainQuery() {
 				[ 'city_id' => $domain->city_id ]
 			);
 			if ( $row ) {
-				if ( $row->city_path === WikiFactory::SLOT_1 ) {
+				if ( !WikiFactory::isUCPPath( $row->city_path ) ) {
 					$domain->city_domain = strtolower( $domain->city_domain );
 					$rxp_query = preg_quote( $query, '/' );
 

--- a/extensions/wikia/WikiFactory/WikiFactory.php
+++ b/extensions/wikia/WikiFactory/WikiFactory.php
@@ -3640,7 +3640,21 @@ class WikiFactory {
 	}
 
 	/**
-	 * Returns true if city_path for given wiki is equal to static::SLOT_1
+	 * Returns true if a given city path is equal to static::SLOT_2
+	 *
+	 * @access public
+	 * @static
+	 *
+	 * @param string $city_path
+	 *
+	 * @return boolean
+	 */
+	static public function isUCPPath( $city_path ) {
+		return $city_path === static::SLOT_2;
+	}
+
+	/**
+	 * Returns true for UCP wikis
 	 *
 	 * @access public
 	 * @static
@@ -3650,6 +3664,6 @@ class WikiFactory {
 	 * @return boolean
 	 */
 	static public function isUCPWiki( $city_id ) {
-		return WikiFactory::getCityPath( $city_id ) === static::SLOT_2;
+		return self::isUCPPath( self::getCityPath( $city_id ) );
 	}
 }

--- a/extensions/wikia/WikiFactory/templates/listing.tmpl.php
+++ b/extensions/wikia/WikiFactory/templates/listing.tmpl.php
@@ -10,7 +10,7 @@ $cnt = 0;
 foreach( $data as $row ):
 ?>
 <div class="wf-list">
-	<?php if ( $row->wiki->city_path === WikiFactory::SLOT_1 ): ?>
+	<?php if ( !WikiFactory::isUCPPath( $row->wiki->city_path ) ): ?>
 		<h4><a href="<?php echo $title->getFullUrl() . "/{$row->wiki->city_id}" ?>">
 			<?php CityListPager::bold( $row->wiki->city_title, $part )?>
 			<span style="font-size: smaller">language: <?php echo $row->wiki->city_lang ?></span>


### PR DESCRIPTION
caused by https://github.com/Wikia/app/pull/17702/files where the `SLOT_1` constant was removed. Apparently is was still in use.