### PR TITLE
Always check with affiliate service

### DIFF
--- a/extensions/wikia/AffiliateService/js/ext.AffiliateService.js
+++ b/extensions/wikia/AffiliateService/js/ext.AffiliateService.js
@@ -117,6 +117,11 @@ require([
 		},
 
 		canDisplayUnit: function () {
+			if (AffiliateService.getDebugTargeting() !== false) {
+				return true;
+			}
+
+			// you're logged out?
 			return !w.wgUserName;
 		},
 

--- a/extensions/wikia/AffiliateService/js/ext.AffiliateService.js
+++ b/extensions/wikia/AffiliateService/js/ext.AffiliateService.js
@@ -117,25 +117,7 @@ require([
 		},
 
 		canDisplayUnit: function () {
-			// you're logged out?
-			if (!w.wgUserName) {
-				if (AffiliateService.isHuluCommunity()) {
-					return true;
-				}
-
-				// is that wiki whitelisted?
-				if (w.wgAffiliateEnabled) {
-					return true;
-				}
-
-				// do we have debug targeting
-				if (AffiliateService.getDebugTargeting() !== false) {
-					return true;
-				}
-			}
-
-			// tough luck
-			return false;
+			return !w.wgUserName;
 		},
 
 		getStartHeight: function () {


### PR DESCRIPTION
This removes the flag that we were using for which communities we want to target. This will increase the number of requests for the service. 

Do we feel comfortable with this change? Should we do the math and see if the service can handle this? The big communities are already enabled. 

@Wikia/cake 
@Wikia/lore 