### PR TITLE
(SER-3939) Make sure wgCentralWikiId is set on preview

### DIFF
--- a/includes/wikia/VariablesBase.php
+++ b/includes/wikia/VariablesBase.php
@@ -1018,6 +1018,13 @@ $wgCategoryMagicGallery = true;
 $wgCategoryPagingLimit = 200;
 
 /**
+ * Points to ucp-internal-test-community.fandom.com.
+ * Should be switched to ucp.fandom.com for initial rollout and to community.fandom.com after
+ * Community Central has been migrated to UCP.
+ */
+$wgCentralWikiId = 2182188;
+
+/**
  * Chat server API address. Normally it is resolved by consul, but for
  * development and testing purposes you can specify it here.
  * @see ChatConfig::getApiServer()


### PR DESCRIPTION
wgCentralWikiId was only set in prod.php and dev.php so it was not being applied
on our staging environments like preview, verify, and sandboxes.

/cc @Wikia/services-team 