### PR TITLE
CAKE-5590 | Enable Google Tag Manager by Default

### DIFF
--- a/extensions/wikia/GoogleTagManager/GoogleTagManagerHooks.class.php
+++ b/extensions/wikia/GoogleTagManager/GoogleTagManagerHooks.class.php
@@ -11,7 +11,7 @@ class GoogleTagManagerHooks {
 	
 	public static function onBeforePageDisplay( OutputPage $out ) {
 		wfProfileIn( __METHOD__ );
-		global $wgEnableGoogleTagManager;
+		global $wgEnableGoogleTagManagerExt;
 
 		$tagManagerNoScript = '<!-- Google Tag Manager (noscript) --><noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-MDPTN53" height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript><!-- End Google Tag Manager (noscript) -->';
 

--- a/extensions/wikia/GoogleTagManager/GoogleTagManagerHooks.class.php
+++ b/extensions/wikia/GoogleTagManager/GoogleTagManagerHooks.class.php
@@ -11,8 +11,6 @@ class GoogleTagManagerHooks {
 	
 	public static function onBeforePageDisplay( OutputPage $out ) {
 		wfProfileIn( __METHOD__ );
-		global $wgEnableGoogleTagManagerExt;
-
 		$tagManagerNoScript = '<!-- Google Tag Manager (noscript) --><noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-MDPTN53" height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript><!-- End Google Tag Manager (noscript) -->';
 
 		$out->addModules( 'ext.wikia.GoogleTagManager' );

--- a/extensions/wikia/GoogleTagManager/README.md
+++ b/extensions/wikia/GoogleTagManager/README.md
@@ -1,1 +1,1 @@
-Google Tag Manager Snippet loads when $wgEnableGoogleTagManager is set to true in Wiki Factory.
+Google Tag Manager Snippet loads when $wgEnableGoogleTagManagerExt is set to true in Wiki Factory.

--- a/includes/wikia/Extensions.php
+++ b/includes/wikia/Extensions.php
@@ -558,7 +558,7 @@ if( !empty( $wgEnableGoogleDocsExt ) ) {
 	include( "$IP/extensions/wikia/GoogleDocs/GoogleDocs.php" );
 }
 
-if( !empty( $wgEnableGoogleTagManager ) ) {
+if( !empty( $wgEnableGoogleTagManagerExt ) ) {
 	include( "$IP/extensions/wikia/GoogleTagManager/GoogleTagManager.setup.php" );
 }
 

--- a/includes/wikia/VariablesBase.php
+++ b/includes/wikia/VariablesBase.php
@@ -2793,7 +2793,7 @@ $wgEnableGoogleDocsExt = true;
 $wgEnableGoogleFormTagExt = true;
 
 /**
- * Enable GoogleTagManager
+ * Enables GoogleTagManager by default
  * @see /extensions/wikia/GoogleTagManager
  * @var bool $wgEnableGoogleTagManager
  */

--- a/includes/wikia/VariablesBase.php
+++ b/includes/wikia/VariablesBase.php
@@ -2797,7 +2797,7 @@ $wgEnableGoogleFormTagExt = true;
  * @see /extensions/wikia/GoogleTagManager
  * @var bool $wgEnableGoogleTagManager
  */
-$wgGoogleTagManager = true;
+$wgEnableGoogleTagManager = true;
 
 /**
  * Enable Gracenote extension for Lyrics. Defaults to false, toggled in

--- a/includes/wikia/VariablesBase.php
+++ b/includes/wikia/VariablesBase.php
@@ -2793,6 +2793,13 @@ $wgEnableGoogleDocsExt = true;
 $wgEnableGoogleFormTagExt = true;
 
 /**
+ * Enable GoogleTagManager
+ * @see /extensions/wikia/GoogleTagManager
+ * @var bool $wgEnableGoogleTagManager
+ */
+$wgGoogleTagManager = true;
+
+/**
  * Enable Gracenote extension for Lyrics. Defaults to false, toggled in
  * WikiFactory.
  * @see extensions/3rdparty/LyricWiki/Gracenote

--- a/includes/wikia/VariablesBase.php
+++ b/includes/wikia/VariablesBase.php
@@ -2793,11 +2793,11 @@ $wgEnableGoogleDocsExt = true;
 $wgEnableGoogleFormTagExt = true;
 
 /**
- * Enables GoogleTagManager by default
+ * Enables Google Tag Manager by default
  * @see /extensions/wikia/GoogleTagManager
- * @var bool $wgEnableGoogleTagManager
+ * @var bool $wgEnableGoogleTagManagerExt
  */
-$wgEnableGoogleTagManager = true;
+$wgEnableGoogleTagManagerExt = true;
 
 /**
  * Enable Gracenote extension for Lyrics. Defaults to false, toggled in


### PR DESCRIPTION
Set **wgEnableGoogleTagManager** to true to enable extension on all communities by default.