### PR TITLE
CAKE-5591 | Only show units on specific namespace

### DIFF
--- a/extensions/wikia/AffiliateService/AffiliateServiceHooks.class.php
+++ b/extensions/wikia/AffiliateService/AffiliateServiceHooks.class.php
@@ -13,75 +13,14 @@ class AffiliateServiceHooks {
 	public static function onWikiaSkinTopScripts( Array &$vars, &$scripts ) {
 		wfProfileIn( __METHOD__ );
 
-		global $wgTitle, $wgCityId;
+		global $wgTitle;
 		// Proper namespace => Article (NS 0) and not Main Pages
 		$isProperNamespace = is_object( $wgTitle )
 			&& ( !$wgTitle->isMainPage() )
 			&& ( $wgTitle->getNamespace() === NS_MAIN );
 
-		// generated list to continue soft rollout
-		$allowedCityIds = [
-			1000000311,
-			113,
-			1163770,
-			119,
-			1249,
-			125,
-			13346,
-			1456064,
-			147,
-			1544,
-			1706,
-			174,
-			175043,
-			177996,
-			2061,
-			20780,
-			2154,
-			2233,
-			2237,
-			250551,
-			2520,
-			2569,
-			277,
-			283,
-			2860,
-			3035,
-			3124,
-			3125,
-			31618,
-			323,
-			3469,
-			3510,
-			374,
-			376,
-			4097,
-			410,
-			4541,
-			462,
-			48473,
-			490,
-			509,
-			530,
-			5975,
-			663,
-			673,
-			68170,
-			691,
-			74,
-			78127,
-			831,
-			833670,
-			835,
-			916058,
-			932,
-			95,
-			984,
-		];
-		$isProperCommunity = Wikia::isDevEnv() || in_array( $wgCityId, $allowedCityIds );
-
-		// only enable it onNS 0 AND dev env
-		$vars['wgAffiliateEnabled'] = $isProperNamespace && $isProperCommunity;
+		// only enable on proper namespaces
+		$vars['wgAffiliateEnabled'] = $isProperNamespace;
 
 		// add translations from AffiliateService.i18n.php
 		$vars['disclaimerMessage'] = wfMessage('affiliate-service-disclaimer')->plain();

--- a/extensions/wikia/AffiliateService/js/ext.AffiliateService.js
+++ b/extensions/wikia/AffiliateService/js/ext.AffiliateService.js
@@ -121,8 +121,13 @@ require([
 				return true;
 			}
 
-			// you're logged out?
-			return !w.wgUserName;
+			// is this the proper namespace and logged out
+			if (w.wgAffiliateEnabled && !w.wgUserName) {
+				return true;
+			}
+
+			// out of luck
+			return false;
 		},
 
 		getStartHeight: function () {


### PR DESCRIPTION
https://github.com/Wikia/app/pull/17785/ caused a regression because we were no longer checking with the namespace. 



@Wikia/cake 