### PR TITLE
SER-3936 | remove user cache after rename

### DIFF
--- a/lib/Wikia/src/Tasks/Tasks/RenameUserPagesTask.php
+++ b/lib/Wikia/src/Tasks/Tasks/RenameUserPagesTask.php
@@ -83,6 +83,6 @@ class RenameUserPagesTask extends BaseTask {
 		}
 
 		$user = User::newFromName( $newUserName );
-		$user->invalidateCache();
+		$user->deleteCache();
 	}
 }


### PR DESCRIPTION
https://wikia-inc.atlassian.net/browse/SER-3936

`User->deleteCache()` seems to be the most reliable way to remove local user cache after updating the database.