### PR TITLE
CAKE-5613 | Better handling for non-portable infoboxes & CSS fix

### DIFF
--- a/extensions/wikia/AffiliateService/js/ext.AffiliateService.js
+++ b/extensions/wikia/AffiliateService/js/ext.AffiliateService.js
@@ -132,7 +132,7 @@ require([
 
 		getStartHeight: function () {
 			if (AffiliateService.$infoBox.length === 0) {
-				return 0;
+				return 2000; // when no infobox, fall back to at least 2000 pixels down the page
 			}
 
 			var infoBoxOffset = AffiliateService.$infoBox.offset();
@@ -416,7 +416,11 @@ require([
 		},
 
 		init: function () {
-			AffiliateService.$infoBox = $('.portable-infobox').first();
+			if ($('.portable-infobox').length > 0) {
+				AffiliateService.$infoBox = $('.portable-infobox').first();
+			} else if ($('.infobox').length > 0) {
+				AffiliateService.$infoBox = $('.infobox').first();
+			}
 
 			if (!AffiliateService.canDisplayUnit()) {
 				return;

--- a/extensions/wikia/AffiliateService/js/ext.AffiliateService.js
+++ b/extensions/wikia/AffiliateService/js/ext.AffiliateService.js
@@ -132,7 +132,7 @@ require([
 
 		getStartHeight: function () {
 			if (AffiliateService.$infoBox.length === 0) {
-				return 2000; // when no infobox, fall back to at least 2000 pixels down the page
+				return 0;
 			}
 
 			var infoBoxOffset = AffiliateService.$infoBox.offset();

--- a/extensions/wikia/AffiliateService/styles/affiliate-unit.scss
+++ b/extensions/wikia/AffiliateService/styles/affiliate-unit.scss
@@ -94,7 +94,7 @@
 
     &__logo {
         bottom: 12px;
-        height: 34px;
+        height: 34px !important; // some communities have extra styles
         position: absolute;
         right: 18px;
 


### PR DESCRIPTION
* Adjusted the fallback pixel location to prevent the unit from appearing so high on the page 
* Added `.infobox` for the height calculation

TODO: 
* Prevent the unit from breaking when the width is narrower. 

@Wikia/cake 
@rybmat 