### PR TITLE
adding campaign and category to the HTML to use with the Optimizely test

### DIFF
--- a/extensions/wikia/AffiliateService/js/ext.AffiliateService.js
+++ b/extensions/wikia/AffiliateService/js/ext.AffiliateService.js
@@ -448,6 +448,8 @@ require([
 				logoDark: unit.logo ? unit.logo.dark : null,
 				showDisclaimer: !isWatchShowEnabled,
 				disclaimerMessage: w.disclaimerMessage,
+				campaign: unit.campaign,
+				category: unit.category
 			});
 		},
 

--- a/extensions/wikia/AffiliateService/js/templates.js
+++ b/extensions/wikia/AffiliateService/js/templates.js
@@ -16,7 +16,7 @@ define( 'ext.wikia.AffiliateService.templates', [], function() {
                 + '</p>';
         }
 
-        return '<div class="aff-unit__wrapper">'
+        return '<div class="aff-unit__wrapper" data-campaign="' + options.campaign + '" data-category="' + options.category + '">'
             + '<a class="aff-unit__link" href="' + options.link + '" target="_blank">'
             + '<div class="aff-unit__image-wrapper" style="background-image: url(' + options.image + ')"></div>'
             + '<div class="aff-unit__info">'


### PR DESCRIPTION
Adding some attributes, so that I can test against those during the Optimizely tests. I'm not worried about exposing them, because the same info is already available in the tracking urls. 