### PR TITLE
SER-3981 Header to disable closed wiki handling

### DIFF
--- a/extensions/wikia/WikiFactory/Loader/WikiFactoryLoader.php
+++ b/extensions/wikia/WikiFactory/Loader/WikiFactoryLoader.php
@@ -76,7 +76,7 @@ class WikiFactoryLoader {
 		 *
 		 * @see SUS-6026
 		 */
-		$this->mCommandLine = $wgCommandLineMode;
+		$this->mCommandLine = $wgCommandLineMode || !empty( $server['HTTP_X_DISABLE_CLOSED_WIKI_HANDLING'] );
 
 		if ( !empty( $server['HTTP_X_MW_WIKI_ID'] ) ) {
 			// SUS-5816 | a special HTTP request with wiki ID forced via request header

--- a/extensions/wikia/WikiFactory/Loader/WikiFactoryLoader.php
+++ b/extensions/wikia/WikiFactory/Loader/WikiFactoryLoader.php
@@ -76,7 +76,11 @@ class WikiFactoryLoader {
 		 *
 		 * @see SUS-6026
 		 */
-		$this->mCommandLine = $wgCommandLineMode || !empty( $server['HTTP_X_DISABLE_CLOSED_WIKI_HANDLING'] );
+		$this->mCommandLine = $wgCommandLineMode || (
+				// SER-3981 RTBF process has been moved to UCP, the tasks need to be run on closed wikis
+				!empty( $server['HTTP_X_DISABLE_CLOSED_WIKI_HANDLING'] )
+				&& !empty( $server['HTTP_X_WIKIA-INTERNAL-REQUEST'] )
+			);
 
 		if ( !empty( $server['HTTP_X_MW_WIKI_ID'] ) ) {
 			// SUS-5816 | a special HTTP request with wiki ID forced via request header


### PR DESCRIPTION
The RTBF process was moved to UCP and rather than integrating UCP with Celery, some actions are done by calling app directly via Nirvana controllers. Unfortunately this clashes with the 410 Wiki gone responses returned for closed wikis.

This *temporary* fix, will allow us to run RTBF on closed wikis (which may still be recovered, so the process needs to run on them).