### PR TITLE
IW-3381 | Introduce read only state for article comments

### DIFF
--- a/extensions/wikia/ArticleComments/classes/ArticleCommentsAjax.class.php
+++ b/extensions/wikia/ArticleComments/classes/ArticleCommentsAjax.class.php
@@ -28,7 +28,7 @@ class ArticleCommentsAjax {
 	 * @return String -- json-ized array
 	 */
 	static public function axSave() {
-		global $wgRequest, $wgUser, $wgTitle;
+		global $wgRequest, $wgUser, $wgTitle, $wgArticleCommentsReadOnlyMode;
 
 		$articleId = $wgRequest->getVal( 'article', false );
 		$commentId = $wgRequest->getVal( 'id', false );
@@ -46,6 +46,12 @@ class ArticleCommentsAjax {
 		// Return with error if we can't find the article
 		$title = Title::newFromID( $articleId );
 		if ( !$title ) {
+			return $errorResult;
+		}
+
+		if ( $wgArticleCommentsReadOnlyMode ) {
+			$errorResult['msg'] = 'Comments are currently read only';
+
 			return $errorResult;
 		}
 
@@ -176,9 +182,13 @@ class ArticleCommentsAjax {
 	 * @return array
 	 */
 	static public function axPost() {
-		global $wgRequest, $wgUser, $wgLang;
+		global $wgRequest, $wgUser, $wgLang, $wgArticleCommentsReadOnlyMode;
 
 		$result = [ 'error' => 1 ];
+
+		if ( $wgArticleCommentsReadOnlyMode ) {
+			return $result;
+		}
 
 		try {
 			$wgRequest->assertValidWriteRequest( $wgUser );

--- a/extensions/wikia/ArticleComments/modules/ArticleCommentsController.class.php
+++ b/extensions/wikia/ArticleComments/modules/ArticleCommentsController.class.php
@@ -25,7 +25,7 @@ class ArticleCommentsController extends WikiaController {
 	 */
 	public function content() {
 		//this is coming via ajax we need to set correct wgTitle ourselves
-		global $wgTitle;
+		global $wgTitle, $wgArticleCommentsReadOnlyMode;
 
 		$articleId = $this->request->getVal( 'articleId', null );
 		$page = $this->request->getVal( 'page', 1 );
@@ -48,6 +48,7 @@ class ArticleCommentsController extends WikiaController {
 
 		$this->getCommentsData( $title, $page );
 		$this->isMiniEditorEnabled = ArticleComment::isMiniEditorEnabled();
+		$this->setVal('readOnly', $wgArticleCommentsReadOnlyMode);
 
 		// Uncomment this when surrogate key purging works
 		//Wikia::setSurrogateKeysHeaders( ArticleComment::getSurrogateKey( $articleId ) );

--- a/extensions/wikia/ArticleComments/modules/templates/ArticleCommentsController_Content.php
+++ b/extensions/wikia/ArticleComments/modules/templates/ArticleCommentsController_Content.php
@@ -3,7 +3,7 @@
 </ul>
 <h1 id="article-comments-counter-header"><?= wfMessage( 'oasis-comments-header' )->numParams( $countCommentsNested )->parse() ?></h1>
 <div id="article-comments" class="article-comments">
-	<? if ( !$isBlocked && $commentingAllowed ): ?>
+	<? if ( !$isBlocked && $commentingAllowed && !$readOnly ): ?>
 		<? if ( $isMiniEditorEnabled ): ?>
 			<?= $app->renderView( 'MiniEditorController', 'Setup' ) ?>
 		<? endif ?>

--- a/extensions/wikia/ArticleComments/modules/templates/ArticleComments_Comment.php
+++ b/extensions/wikia/ArticleComments/modules/templates/ArticleComments_Comment.php
@@ -13,7 +13,8 @@
 		<div class="edited-by">
 		<?= wfMessage( 'oasis-comments-added-by' )->rawParams( $comment['timestamp'], $comment['sig'] )->escaped() ?>
 		<?php if (!empty($comment['isStaff'])) { print "<span class=\"stafflogo\"><img src=\"".wfReplaceImageServer( wfGetSignatureUrl() ) . "\" title=\"This user is a member of Fandom staff\" alt=\"@fandom\" /></span>\n"; } ?>
-		<?php if (count($comment['buttons']) || $comment['replyButton']) { ?>
+		<?php global $wgArticleCommentsReadOnlyMode;
+		if (!$wgArticleCommentsReadOnlyMode && (count($comment['buttons']) || $comment['replyButton'])) { ?>
 			<div class="buttons">
 				<?php echo $comment['replyButton']; ?>
 				<span class="tools">

--- a/includes/wikia/VariablesBase.php
+++ b/includes/wikia/VariablesBase.php
@@ -2241,6 +2241,11 @@ $wgEnableAPI = true;
 $wgEnableArticleCommentsExt = false;
 
 /**
+ * Used to put article comments extension in readonly mode
+ */
+$wgArticleCommentsReadOnlyMode = false;
+
+/**
  * Enable ArticleVideo extension.
  * @see extensions/wikia/ArticleVideo
  * @see extensions/wikia/SiteWideMessages


### PR DESCRIPTION
https://wikia-inc.atlassian.net/browse/IW-3046
https://wikia-inc.atlassian.net/browse/IW-3381

For the time of article comments being migrated to discussions (part of migrating wiki to UCP), we need to make them read only.

@Wikia/iwing 