### PR TITLE
Cake 5676 | Move Create New Wiki to Google Cloud Storage

### DIFF
--- a/extensions/wikia/CreateNewWiki/classes/Starters.class.php
+++ b/extensions/wikia/CreateNewWiki/classes/Starters.class.php
@@ -73,7 +73,7 @@ class Starters {
 	 * @return string
 	 */
 	public static function getStarterContentDumpPath( $starter ) {
-		return sprintf( '/dumps/%s.xml.bz2', $starter );
+		return sprintf( 'dumps/%s.xml.bz2', $starter );
 	}
 
 	/**
@@ -83,7 +83,7 @@ class Starters {
 	 * @return string
 	 */
 	public static function getStarterSqlDumpPath( $starter ) {
-		return sprintf( '/dumps/%s.sql.bz2', $starter );
+		return sprintf( 'dumps/%s.sql.bz2', $starter );
 	}
 
 	/**

--- a/extensions/wikia/CreateNewWiki/classes/Starters.class.php
+++ b/extensions/wikia/CreateNewWiki/classes/Starters.class.php
@@ -73,7 +73,7 @@ class Starters {
 	 * @return string
 	 */
 	public static function getStarterContentDumpPath( $starter ) {
-		return sprintf( 'dumps/%s.xml.bz2', $starter );
+		return sprintf( 'starter/%s.xml.bz2', $starter );
 	}
 
 	/**
@@ -83,17 +83,6 @@ class Starters {
 	 * @return string
 	 */
 	public static function getStarterSqlDumpPath( $starter ) {
-		return sprintf( 'dumps/%s.sql.bz2', $starter );
-	}
-
-	/**
-	 * Return SwiftStorage instance used to upload and fetch XML dumps
-	 *
-	 * @return SwiftStorage
-	 */
-	public static function getStarterDumpStorage() {
-		global $wgCreateWikiStarterDumpsDatacenter;
-		// SRE: make sure to always use proper Swift
-		return SwiftStorage::newFromContainer( self::STARTER_DUMPS_BUCKET, '', $wgCreateWikiStarterDumpsDatacenter );
+		return sprintf( 'starter/%s.sql.bz2', $starter );
 	}
 }

--- a/extensions/wikia/CreateNewWiki/maintenance/dumpStarters.php
+++ b/extensions/wikia/CreateNewWiki/maintenance/dumpStarters.php
@@ -1,6 +1,5 @@
 <?php
 use Google\Cloud\Storage\StorageClient;
-use Wikia\CreateNewWiki\Tasks\ImportStarterData;
 
 /**
  * Script that prepares XML and SQL dumps with the latest revisions and *links tables rows of starter wikis
@@ -24,6 +23,9 @@ class DumpStartersException extends Exception {}
 class DumpStarters extends Maintenance {
 
 	const DUMP_MIME_TYPE = 'application/bzip2';
+	
+	const BUCKET_NAME_PROD = 'create-new-wiki';
+	const BUCKET_NAME_DEV - 'create-new-wiki-dev';
 
 	protected $mDescription = 'This script prepares XML and SQL dumps of starter wikis';
 
@@ -124,10 +126,10 @@ class DumpStarters extends Maintenance {
 		global $wgWikiaEnvironment;
 		global $wgGcsConfig;
 
-		$bucketName = ImportStarterData::BUCKET_NAME_PROD;
+		$bucketName = self::BUCKET_NAME_PROD;
 
 		if ( $wgWikiaEnvironment == 'dev' ) {
-			$bucketName = ImportStarterData::BUCKET_NAME_DEV;
+			$bucketName = self::BUCKET_NAME_DEV;
 		}
 
 		$this->output( sprintf( " \n\t[%s / %.2f kB]", $dest, filesize( $filename ) / 1024 ) );

--- a/extensions/wikia/CreateNewWiki/maintenance/dumpStarters.php
+++ b/extensions/wikia/CreateNewWiki/maintenance/dumpStarters.php
@@ -24,8 +24,8 @@ class DumpStarters extends Maintenance {
 
 	const DUMP_MIME_TYPE = 'application/bzip2';
 	
-	const BUCKET_NAME_PROD = 'create-new-wiki';
 	const BUCKET_NAME_DEV = 'create-new-wiki-dev';
+	const BUCKET_NAME_PROD = 'create-new-wiki';
 
 	protected $mDescription = 'This script prepares XML and SQL dumps of starter wikis';
 
@@ -123,8 +123,7 @@ class DumpStarters extends Maintenance {
 	 * @throws DumpStartersException
 	 */
 	private function storeDump( $filename, $dest ) {
-		global $wgWikiaEnvironment;
-		global $wgGcsConfig;
+		global $wgWikiaEnvironment, $wgGcsConfig;
 
 		$bucketName = self::BUCKET_NAME_PROD;
 

--- a/extensions/wikia/CreateNewWiki/maintenance/dumpStarters.php
+++ b/extensions/wikia/CreateNewWiki/maintenance/dumpStarters.php
@@ -123,10 +123,10 @@ class DumpStarters extends Maintenance {
 		global $wgWikiaEnvironment;
 		global $wgGcsConfig;
 
-		$bucketName = 'create-new-wiki';
+		$bucketName = \Wikia\CreateNewWiki\tasks\ImportStarterData::BUCKET_NAME_PROD;
 
 		if ( $wgWikiaEnvironment == 'dev' ) {
-			$bucketName = 'create-new-wiki-dev';
+			$bucketName = \Wikia\CreateNewWiki\tasks\ImportStarterData::BUCKET_NAME_DEV;
 		}
 
 		$this->output( sprintf( " \n\t[%s / %.2f kB]", $dest, filesize( $filename ) / 1024 ) );

--- a/extensions/wikia/CreateNewWiki/maintenance/dumpStarters.php
+++ b/extensions/wikia/CreateNewWiki/maintenance/dumpStarters.php
@@ -1,5 +1,6 @@
 <?php
 use Google\Cloud\Storage\StorageClient;
+use \Wikia\CreateNewWiki\tasks\ImportStarterData;
 
 /**
  * Script that prepares XML and SQL dumps with the latest revisions and *links tables rows of starter wikis
@@ -123,10 +124,10 @@ class DumpStarters extends Maintenance {
 		global $wgWikiaEnvironment;
 		global $wgGcsConfig;
 
-		$bucketName = \Wikia\CreateNewWiki\tasks\ImportStarterData::BUCKET_NAME_PROD;
+		$bucketName = ImportStarterData::BUCKET_NAME_PROD;
 
 		if ( $wgWikiaEnvironment == 'dev' ) {
-			$bucketName = \Wikia\CreateNewWiki\tasks\ImportStarterData::BUCKET_NAME_DEV;
+			$bucketName = ImportStarterData::BUCKET_NAME_DEV;
 		}
 
 		$this->output( sprintf( " \n\t[%s / %.2f kB]", $dest, filesize( $filename ) / 1024 ) );

--- a/extensions/wikia/CreateNewWiki/maintenance/dumpStarters.php
+++ b/extensions/wikia/CreateNewWiki/maintenance/dumpStarters.php
@@ -1,6 +1,5 @@
 <?php
 use Google\Cloud\Storage\StorageClient;
-use \Wikia\CreateNewWiki\tasks\ImportStarterData;
 
 /**
  * Script that prepares XML and SQL dumps with the latest revisions and *links tables rows of starter wikis
@@ -124,10 +123,10 @@ class DumpStarters extends Maintenance {
 		global $wgWikiaEnvironment;
 		global $wgGcsConfig;
 
-		$bucketName = ImportStarterData::BUCKET_NAME_PROD;
+		$bucketName = 'create-new-wiki';
 
 		if ( $wgWikiaEnvironment == 'dev' ) {
-			$bucketName = ImportStarterData::BUCKET_NAME_DEV;
+			$bucketName = 'create-new-wiki-dev';
 		}
 
 		$this->output( sprintf( " \n\t[%s / %.2f kB]", $dest, filesize( $filename ) / 1024 ) );

--- a/extensions/wikia/CreateNewWiki/maintenance/dumpStarters.php
+++ b/extensions/wikia/CreateNewWiki/maintenance/dumpStarters.php
@@ -25,7 +25,7 @@ class DumpStarters extends Maintenance {
 	const DUMP_MIME_TYPE = 'application/bzip2';
 	
 	const BUCKET_NAME_PROD = 'create-new-wiki';
-	const BUCKET_NAME_DEV - 'create-new-wiki-dev';
+	const BUCKET_NAME_DEV = 'create-new-wiki-dev';
 
 	protected $mDescription = 'This script prepares XML and SQL dumps of starter wikis';
 

--- a/extensions/wikia/CreateNewWiki/maintenance/dumpStarters.php
+++ b/extensions/wikia/CreateNewWiki/maintenance/dumpStarters.php
@@ -1,5 +1,6 @@
 <?php
 use Google\Cloud\Storage\StorageClient;
+use Wikia\CreateNewWiki\Tasks\ImportStarterData;
 
 /**
  * Script that prepares XML and SQL dumps with the latest revisions and *links tables rows of starter wikis
@@ -123,10 +124,10 @@ class DumpStarters extends Maintenance {
 		global $wgWikiaEnvironment;
 		global $wgGcsConfig;
 
-		$bucketName = 'create-new-wiki';
+		$bucketName = ImportStarterData::BUCKET_NAME_PROD;
 
 		if ( $wgWikiaEnvironment == 'dev' ) {
-			$bucketName = 'create-new-wiki-dev';
+			$bucketName = ImportStarterData::BUCKET_NAME_DEV;
 		}
 
 		$this->output( sprintf( " \n\t[%s / %.2f kB]", $dest, filesize( $filename ) / 1024 ) );

--- a/extensions/wikia/CreateNewWiki/maintenance/dumpStarters.php
+++ b/extensions/wikia/CreateNewWiki/maintenance/dumpStarters.php
@@ -1,5 +1,4 @@
 <?php
-
 use Google\Cloud\Storage\StorageClient;
 
 /**
@@ -121,12 +120,21 @@ class DumpStarters extends Maintenance {
 	 * @throws DumpStartersException
 	 */
 	private function storeDump( $filename, $dest ) {
+		global $wgWikiaEnvironment;
+
+		$bucketName = 'create-new-wiki';
+
+		if ( $wgWikiaEnvironment == 'dev' ) {
+			$bucketName = 'create-new-wiki-dev';
+		}
+
 		$this->output( sprintf( " \n\t[%s / %.2f kB]", $dest, filesize( $filename ) / 1024 ) );
 
 		$storage = new StorageClient( [ 'keyFile' => $wgGcsConfig['gcsCredentials'] ] );
 		$content = fopen( $filename, 'r' );
-		$bucket = $storage->bucket( 'create-new-wiki' );
-		$object = $bucket->upload( $content, [ 'name' => sprintf( 'app/%s', $dest ) ] );
+		$bucket = $storage->bucket( $bucketName );
+		$gcsPath = sprintf( 'app/%s', $dest );
+		$object = $bucket->upload( $content, [ 'name' => $gcsPath ] );
 
 		if ( is_null( $object ) ) {
 			throw new Exception( "Unable to store a dump for {$dest}" );

--- a/extensions/wikia/CreateNewWiki/maintenance/dumpStarters.php
+++ b/extensions/wikia/CreateNewWiki/maintenance/dumpStarters.php
@@ -121,6 +121,7 @@ class DumpStarters extends Maintenance {
 	 */
 	private function storeDump( $filename, $dest ) {
 		global $wgWikiaEnvironment;
+		global $wgGcsConfig;
 
 		$bucketName = 'create-new-wiki';
 

--- a/extensions/wikia/CreateNewWiki/tasks/ImportStarterData.php
+++ b/extensions/wikia/CreateNewWiki/tasks/ImportStarterData.php
@@ -80,10 +80,11 @@ class ImportStarterData extends Task {
 
 		$storage = new StorageClient( [ 'keyFile' => $wgGcsConfig['gcsCredentials'] ] );
 		$bucket = $storage->bucket( $bucketName );
-		$object = $bucket->object( $path );
+		$gcsPath = sprintf( 'app/%s', $path );
+		$object = $bucket->object( $gcsPath );
 
 		if ( is_null( $object ) ) {
-			throw new Exception( "Unable to fetch a dump from {$path}", self::ERR_OPEN_STARTER_DUMP_FAILED );
+			throw new Exception( "Unable to fetch a dump from {$gcsPath}", self::ERR_OPEN_STARTER_DUMP_FAILED );
 		}
 
 		$stream = $object->downloadAsStream();

--- a/extensions/wikia/CreateNewWiki/tasks/ImportStarterData.php
+++ b/extensions/wikia/CreateNewWiki/tasks/ImportStarterData.php
@@ -4,6 +4,8 @@ namespace Wikia\CreateNewWiki\Tasks;
 
 use Wikia\CreateNewWiki\Starters;
 use Wikia\Logger\Loggable;
+use Google\Cloud\Storage\StorageClient;
+use GuzzleHttp\Psr7\StreamWrapper;
 
 class ImportStarterData extends Task {
 
@@ -15,6 +17,9 @@ class ImportStarterData extends Task {
 	const ERR_RUN_UPDATES_FAILED = 4;
 
 	const MAX_REPLICATION_WAIT_MILLIS = 1250;
+
+	const BUCKET_NAME_PROD = 'create-new-wiki';
+	const BUCKET_NAME_DEV = 'create-new-wiki-dev';
 
 	public function run() {
 		global $wgContLang;
@@ -64,17 +69,28 @@ class ImportStarterData extends Task {
 	 * @throws \CreateWikiException
 	 */
 	private function getDump( $path ) {
-		$stream = fopen( "php://memory", "wb" );
+		global $wgGcsConfig;
+		global $wgWikiaEnvironment;
+
+		$bucketName = self::BUCKET_NAME_PROD;
+
+		if ( $wgWikiaEnvironment == 'dev' ) {
+			$bucketName = self::BUCKET_NAME_DEV;
+		}
+
+		$storage = new StorageClient( [ 'keyFile' => $wgGcsConfig['gcsCredentials'] ] );
+		$bucket = $storage->bucket( $bucketName );
+		$object = $bucket->object( $path );
+
+		if ( is_null( $object ) ) {
+			throw new Exception( "Unable to fetch a dump from {$path}", self::ERR_OPEN_STARTER_DUMP_FAILED );
+		}
+
+		$stream = $object->downloadAsStream();
+		$stream = StreamWrapper::getResource( $stream );
 
 		if ( !is_resource( $stream ) ) {
 			throw new \CreateWikiException( "Unable to create a memory stream for starter database dump", self::ERR_OPEN_STARTER_DUMP_FAILED );
-		}
-
-		$swift = Starters::getStarterDumpStorage();
-		$res = $swift->read( $path, $stream );
-
-		if ( is_null( $res ) ) {
-			throw new \CreateWikiException( "Unable to fetch a dump from {$path}", self::ERR_OPEN_STARTER_DUMP_FAILED );
 		}
 
 		$stats = fstat( $stream );

--- a/extensions/wikia/CreateNewWiki/tasks/ImportStarterData.php
+++ b/extensions/wikia/CreateNewWiki/tasks/ImportStarterData.php
@@ -69,8 +69,7 @@ class ImportStarterData extends Task {
 	 * @throws \CreateWikiException
 	 */
 	private function getDump( $path ) {
-		global $wgGcsConfig;
-		global $wgWikiaEnvironment;
+		global $wgWikiaEnvironment, $wgGcsConfig;
 
 		$bucketName = self::BUCKET_NAME_PROD;
 


### PR DESCRIPTION
Updates CNW database dump to upload and retrieve starter templates from GCS.

@Wikia/cake 
@Wikia/platform-team 