### PR TITLE
PLATFORM-4759| Try to fix error when reusing Rabbit channels

### DIFF
--- a/lib/Wikia/src/Rabbit/ConnectionManager.php
+++ b/lib/Wikia/src/Rabbit/ConnectionManager.php
@@ -62,7 +62,7 @@ class ConnectionManager {
 	public function getChannel( string $vHost ): AMQPChannel {
 		$this->circuitBreaker->assertOperationAllowed();
 
-		if ( !isset( $this->channels[$vHost] ) ) {
+		if ( !isset( $this->channels[$vHost] ) || !$this->channels[$vHost]->is_open() ) {
 			$this->channels[$vHost] = $this->getConnection( $vHost )->channel();
 
 			// Allow basic_publish to fail in case the connection is blocked by rabbit, due to insufficient resources.


### PR DESCRIPTION
It seems that for long lived processes RabbitMQ channels are closed and when trying to publish some messages after that will result in error:

`Call to a member function prepare_channel_method_frame() on null`

Brief investigation leads to \Wikia\Rabbit\ConnectionManager::getChannel() but this is just a hunch.