### PR TITLE
Disable travis build cache

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -29,10 +29,5 @@ script:
   - git diff $TRAVIS_BRANCH..HEAD --name-only --diff-filter ACMRT | grep \.php$ | grep -Ev '(lib/composer|lib/Swagger|/templates/)' | xargs -n 1 php -l
   - cd tests && ./php-tests.sh
 
-# cache compiled version of pecl extensions
-cache:
-  directories:
-    - /home/travis/.phpenv
-
 notifications:
   email: false


### PR DESCRIPTION
Periodically the travis build cache gets poisoned and needs to be cleared manually. Due to the low volume of activity here these days, let's disable it altogether.