### PR TITLE
Cake 5744 - Affiliate unit updates

### DIFF
--- a/extensions/wikia/AffiliateService/js/ext.AffiliateService.js
+++ b/extensions/wikia/AffiliateService/js/ext.AffiliateService.js
@@ -246,7 +246,9 @@ require([
 				});
 			});
 
-			shuffleArray(availableUnits);
+			// Commenting this out, not deleting at this time, because I want it to be
+			// obvious that it is an active decision to no longer do this! Safe to fully remove after 7/31/2020 - AG
+			// shuffleArray(availableUnits);
 
 			return availableUnits;
 		},

--- a/extensions/wikia/AffiliateService/js/templates.js
+++ b/extensions/wikia/AffiliateService/js/templates.js
@@ -14,8 +14,8 @@ define( 'ext.wikia.AffiliateService.templates', [], function() {
             disclaimer = '<p class="aff-unit__disclaimer-message">'
                 + options.disclaimerMessage;
                     if (options.extraDisclaimer) {
-						disclaimer += ' ' + options.extraDisclaimer
-					}
+                        disclaimer += ' ' + options.extraDisclaimer
+                    }
                 disclaimer += '</p>';
         }
 

--- a/extensions/wikia/AffiliateService/js/templates.js
+++ b/extensions/wikia/AffiliateService/js/templates.js
@@ -4,7 +4,6 @@ define( 'ext.wikia.AffiliateService.templates', [], function() {
     function unit(options) {
         var logos = '';
         var disclaimer = '';
-        var extraDisclaimer = '';
 
         if (options.logoLight) {
             logos = '<img class="aff-unit__logo light" src="' + options.logoLight + '">'
@@ -13,14 +12,11 @@ define( 'ext.wikia.AffiliateService.templates', [], function() {
 
         if (options.showDisclaimer) {
             disclaimer = '<p class="aff-unit__disclaimer-message">'
-                + options.disclaimerMessage
-                + '</p>';
-        }
-
-        if (options.extraDisclaimer) {
-            extraDisclaimer = '<p class="aff-unit__extra-disclaimer-message">'
-                + options.extraDisclaimer
-                + '</p>';
+                + options.disclaimerMessage;
+                    if (options.extraDisclaimer) {
+						disclaimer += ' ' + options.extraDisclaimer
+					}
+                disclaimer += '</p>';
         }
 
         return '<div class="aff-unit__wrapper" data-campaign="' + options.campaign + '" data-category="' + options.category + '">'
@@ -33,8 +29,7 @@ define( 'ext.wikia.AffiliateService.templates', [], function() {
             + '</div>'
             + '</a>'
             + '</div>'
-            + disclaimer + ' '
-            + extraDisclaimer
+            + disclaimer;
     }
 
     return {

--- a/extensions/wikia/AffiliateService/js/units.js
+++ b/extensions/wikia/AffiliateService/js/units.js
@@ -7,7 +7,7 @@ define('ext.wikia.AffiliateService.units', [], function () {
 			country: ['US'],
 			heading: 'Where HBO Meets So Much More',
 			subheading: 'START YOUR FREE TRIAL',
-			link: 'https://www.hbomax.com/gzm',
+			link: 'https://www.hbomax.com/',
 			image: 'https://static.wikia.nocookie.net/05a5bbb9-7662-416e-99c7-6e6700af9aa3',
 			extraDisclaimer: "Free trial for new customers only. Restrictions Apply."
 		},


### PR DESCRIPTION
**Description**
* Removing the randomization of the affiliate units - that time is past, and it's making it harder for the winners to prosper. 
* Cleaned up the extraDisclaimer, to just include it right after the normal one. This was a ChrisS suggestion previously, that in retrospect I now agree with. 
* Fixed the HBOMax link, which was a late change by the sales folks, but was fine because it was being overriden in GTM anyway

@Wikia/cake 
