### PR TITLE
Fix username cache key generation

### DIFF
--- a/includes/wikia/cache/UserNameCacheKeys.php
+++ b/includes/wikia/cache/UserNameCacheKeys.php
@@ -12,7 +12,7 @@ class UserNameCacheKeys {
 	private $username;
 
 	public function __construct( string $username ) {
-		$this->username = urlencode( $username );
+		$this->username = $username;
 	}
 
 	public function getAllKeys(int $wikiId): array {


### PR DESCRIPTION
Reverts "SER-4068 User replication fails for users after rename on dev and prod"