### PR TITLE
[WikiDetailsService] Cache per-wiki visualization data

### DIFF
--- a/includes/wikia/GlobalFile.class.php
+++ b/includes/wikia/GlobalFile.class.php
@@ -27,7 +27,8 @@ class GlobalFile extends WikiaObject implements UrlGeneratorInterface {
 	private function loadData() {
 		if (!isset($this->mData)) {
 			$dbname = WikiFactory::IDtoDB($this->mTitle->mCityId);
-			$dbr = wfGetDB( DB_SLAVE, array(), $dbname );
+			$lb = wfGetLB( $dbname );
+			$dbr = $lb->getConnection( DB_SLAVE, [], $dbname );
 
 			$this->mData = $dbr->selectRow(
 				'image',
@@ -41,6 +42,8 @@ class GlobalFile extends WikiaObject implements UrlGeneratorInterface {
 				['img_name' => $this->mTitle->getDBkey()],
 				__METHOD__
 			);
+
+			$lb->reuseConnection( $dbr );
 		}
 	}
 

--- a/includes/wikia/services/WikiDetailsService.class.php
+++ b/includes/wikia/services/WikiDetailsService.class.php
@@ -10,7 +10,7 @@ class WikiDetailsService extends WikiService {
 	const DEFAULT_WIDTH = 250;
 	const DEFAULT_HEIGHT = null;
 	const DEFAULT_SNIPPET_LENGTH = null;
-	const CACHE_VERSION = 3;
+	const CACHE_VERSION = 4;
 	const WORDMARK_URL_SETTING = 'wordmark-image-url';
 	private static $flagsBlacklist = [ 'blocked', 'promoted' ];
 
@@ -39,6 +39,13 @@ class WikiDetailsService extends WikiService {
 					$this->getFromWAMService( $wikiId ),
 					$this->getFromCommunityData( $wikiId )
 				);
+
+				//post process thumbnails
+				$wikiInfo = array_merge(
+					$wikiInfo,
+					$this->getImageData( $wikiInfo, $width, $height )
+				);
+
 			} else {
 				$wikiInfo = [
 					'id' => (int)$wikiId,
@@ -51,11 +58,7 @@ class WikiDetailsService extends WikiService {
 		if ( isset( $wikiInfo['exists'] ) ) {
 			return [];
 		}
-		//post process thumbnails
-		$wikiInfo = array_merge(
-			$wikiInfo,
-			$this->getImageData( $wikiInfo, $width, $height )
-		);
+
 		//set snippet
 		if ( isset( $wikiInfo['desc'] ) ) {
 			$length = ( $snippet !== null ) ? $snippet : static::DEFAULT_SNIPPET_LENGTH;


### PR DESCRIPTION
WikiDetailsService is heavily used by API calls from recommendations service to
provide wiki metadata, including a representative image. Most of the returned
data is cached, but the image info is always looked up from the DB. As a result,
this code path is responsible for over 25% of sampled queries (via
GlobalFile::loadData method).

As a fix, ensure we also cache the image data. Also fix foreign connection reuse
in GlobalFile.