### PR TITLE
Use Service host rather than ingress via consul for poolcounter

### DIFF
--- a/includes/wikia/VariablesBase.php
+++ b/includes/wikia/VariablesBase.php
@@ -6400,7 +6400,7 @@ $wgPoolCounterConf = null;
  * @see $wgEnablePoolCounter
  * @var Array $wgPoolCounterServers
  */
-$wgPoolCounterServers = [ 'prod.kubernetes-lb-l4.service.consul' ];
+$wgPoolCounterServers = [ 'poolcounter' ];
 
 /**
  * Whether to emit more detailed debug logs for a PoolWorkArticleView


### PR DESCRIPTION
poolcounter and MediaWiki live together in k8s so MediaWiki should use the
Service host for communicating with poolcounter rather than going via the
ingress.