### PR TITLE
Reduce BatchRefreshLinksForTemplate batch size

### DIFF
--- a/lib/Wikia/src/Tasks/Tasks/BatchRefreshLinksForTemplate.php
+++ b/lib/Wikia/src/Tasks/Tasks/BatchRefreshLinksForTemplate.php
@@ -9,6 +9,11 @@ namespace Wikia\Tasks\Tasks;
 
 class BatchRefreshLinksForTemplate extends BaseTask {
 
+	/**
+	 * The maximum number of titles to refresh in a single task execution.
+	 */
+	public const TITLES_PER_TASK = 50;
+
 	const BACKLINK_CACHE_TABLE = 'templatelinks';
 
 	/** @var integer|false $start */


### PR DESCRIPTION
BatchRefreshLinksForTemplate is used to refresh (reparse) articles that depend
on another page, such as a file or template. Currently, each such task reparses
up to 500 articles. We have observed that this batch size is too large; it makes
heavy use of CPU resources and may not complete within the maximum execution
time bounds (180 seconds) allocated for web requests on task executors. Even if
it does complete, a long execution time will mean it will starve other tasks
waiting for execution, thus reducing overall throughput of the task queue each
time there is a spike of BatchRefreshLinksForTemplate tasks due to the
invalidation of some popular page.

As a fix, reduce the batch size of this task tenfold so that it only parses up
to 50 articles per task, rather than 500. This will naturally result in a higher
number of such tasks generated but should result in generally smoother
performance, as smaller, faster tasks should tie up server resources less and
give other tasks a chance to execute. If too many tasks prove to be a problem,
we can move these tasks to a dedicated queue with lower concurrency.