### PR TITLE
IW-3673 | Move Feeds tags API from discussion to Mediawiki

### DIFF
--- a/extensions/wikia/FeedsAndPosts/ArticleTags.class.php
+++ b/extensions/wikia/FeedsAndPosts/ArticleTags.class.php
@@ -10,7 +10,7 @@ use Title;
 use WebRequest;
 
 class ArticleTags {
-	public function getSuggestedTags() {
+	public function getPopularTags() {
 		global $wgCityId;
 
 		$mainPageId = Title::newMainPage()->getArticleID();

--- a/extensions/wikia/FeedsAndPosts/ArticleTags.class.php
+++ b/extensions/wikia/FeedsAndPosts/ArticleTags.class.php
@@ -10,6 +10,8 @@ use Title;
 use WebRequest;
 
 class ArticleTags {
+	const SEARCH_TAGS_LIMIT = 6;
+
 	public function getPopularTags() {
 		global $wgCityId;
 
@@ -53,6 +55,7 @@ class ArticleTags {
 		$request = new WebRequest();
 		$request->setVal( 'format', 'array' );
 		$request->setVal( 'query', $query );
+		$request->setVal( 'limit', 20 );
 
 		$linkSuggestions = LinkSuggest::getLinkSuggest( $request );
 
@@ -64,6 +67,10 @@ class ArticleTags {
 
 		$tags = [];
 		foreach ( $titles as $title ) {
+			if ( $title->isRedirect() ) {
+				continue;
+			}
+
 			$tags[$title->getArticleID()] = [
 				'siteId' => (string)$wgCityId,
 				'articleId' => (string)$title->getArticleID(),
@@ -75,6 +82,10 @@ class ArticleTags {
 		// return items in the order from LinkSuggest
 		$tagsSorted = [];
 		foreach ( array_keys( $linkSuggestions ) as $id ) {
+			if ( count( $tagsSorted ) >= self::SEARCH_TAGS_LIMIT ) {
+				break;
+			}
+
 			if ( array_key_exists( $id, $tags ) ) {
 				$tagsSorted[] = $tags[$id];
 			}

--- a/extensions/wikia/FeedsAndPosts/ArticleTags.class.php
+++ b/extensions/wikia/FeedsAndPosts/ArticleTags.class.php
@@ -1,0 +1,85 @@
+<?php
+
+
+namespace Wikia\FeedsAndPosts;
+
+
+use DataMartService;
+use LinkSuggest;
+use Title;
+use WebRequest;
+
+class ArticleTags {
+	public function getSuggestedTags() {
+		global $wgCityId;
+
+		$mainPageId = Title::newMainPage()->getArticleID();
+		$articleIds = array_keys( DataMartService::getTopArticlesByPageview( $wgCityId, [], [ 0 ], false, 21 ));
+
+		$titles = Title::newFromIDs( $articleIds );
+		$imageServing = new \ImageServing( $articleIds, 200 );
+		$images = $imageServing->getImages( 1 );
+
+		$tags = [];
+		foreach ( $titles as $title ) {
+			$articleId = $title->getArticleID();
+			if ( $articleId != $mainPageId ) {
+				$tags[$articleId] = [
+					'siteId' => (string)$wgCityId,
+					'articleId' => (string)$articleId,
+					'articleTitle' => $title->getText(),
+					'relativeUrl' => $title->getLocalURL(),
+					'image' => !empty($images[$articleId])
+						? $images[$articleId][0]['url']
+						: ''
+				];
+			}
+		}
+
+		// return items in the order from DataMartService::getTopArticlesByPageview
+		$tagsSorted = [];
+		foreach ( $articleIds as $id ) {
+			if ( array_key_exists( $id, $tags ) ) {
+				$tagsSorted[] = $tags[$id];
+			}
+		}
+
+		return $tagsSorted;
+	}
+
+	public function searchTags( string $query ) {
+		global $wgCityId;
+
+		$request = new WebRequest();
+		$request->setVal( 'format', 'array' );
+		$request->setVal( 'query', $query );
+
+		$linkSuggestions = LinkSuggest::getLinkSuggest( $request );
+
+		if ( !is_array( $linkSuggestions ) ) {
+			$linkSuggestions = [];
+		}
+
+		$titles = Title::newFromIDs( array_map( 'intval', array_keys( $linkSuggestions ) ) );
+
+		$tags = [];
+		foreach ( $titles as $title ) {
+			$tags[$title->getArticleID()] = [
+				'siteId' => (string)$wgCityId,
+				'articleId' => (string)$title->getArticleID(),
+				'articleTitle' => $title->getText(),
+				'relativeUrl' => $title->getLocalURL(),
+			];
+		}
+
+		// return items in the order from LinkSuggest
+		$tagsSorted = [];
+		foreach ( array_keys( $linkSuggestions ) as $id ) {
+			if ( array_key_exists( $id, $tags ) ) {
+				$tagsSorted[] = $tags[$id];
+			}
+		}
+
+		return $tagsSorted;
+	}
+}

--- a/extensions/wikia/FeedsAndPosts/FeedsAndPosts.setup.php
+++ b/extensions/wikia/FeedsAndPosts/FeedsAndPosts.setup.php
@@ -15,6 +15,7 @@ $wgAutoloadClasses['Wikia\FeedsAndPosts\ThemeSettings'] = $dir . 'ThemeSettings.
 $wgAutoloadClasses['Wikia\FeedsAndPosts\WikiVariables'] = $dir . 'WikiVariables.class.php';
 $wgAutoloadClasses['Wikia\FeedsAndPosts\ArticleData'] = $dir . 'ArticleData.class.php';
 $wgAutoloadClasses['Wikia\FeedsAndPosts\WikiDetails'] = $dir . 'WikiDetails.class.php';
+$wgAutoloadClasses['Wikia\FeedsAndPosts\ArticleTags'] = $dir . 'ArticleTags.class.php';
 
 
 // Controllers

--- a/extensions/wikia/FeedsAndPosts/FeedsAndPostsController.class.php
+++ b/extensions/wikia/FeedsAndPosts/FeedsAndPostsController.class.php
@@ -52,6 +52,8 @@ class FeedsAndPostsController extends WikiaApiController {
 			return;
 		}
 
+		$popularTags = (new ArticleTags())->getPopularTags();
+
 		if ( $title->exists() ) {
 			$images = ArticleData::getImages( $title->getArticleID() );
 
@@ -62,6 +64,7 @@ class FeedsAndPostsController extends WikiaApiController {
 				'content_images' => count( $images ) > 1 ? array_slice( $images, 1 ) : [],
 				'snippet' => ArticleData::getTextSnippet( $title ),
 				'relativeUrl' => $title->getLocalURL(),
+				'popularTags' => $popularTags
 			] );
 
 			return;
@@ -74,13 +77,14 @@ class FeedsAndPostsController extends WikiaApiController {
 			'content_images' => [],
 			'snippet' => null,
 			'relativeUrl' => $title->getLocalURL(),
+			'popularTags' => $popularTags
 		]);
 	}
 
-	public function getSuggestedTags() {
+	public function getPopularTags() {
 		$this->response->setFormat( WikiaResponse::FORMAT_JSON );
 		$this->response->setCacheValidity( WikiaResponse::CACHE_STANDARD );
-		$this->response->setVal( 'tags', ( new ArticleTags() )->getSuggestedTags() );
+		$this->response->setVal( 'tags', ( new ArticleTags() )->getPopularTags() );
 	}
 
 	public function searchForTags() {

--- a/extensions/wikia/FeedsAndPosts/FeedsAndPostsController.class.php
+++ b/extensions/wikia/FeedsAndPosts/FeedsAndPostsController.class.php
@@ -1,6 +1,7 @@
 <?php
 
 use Wikia\FeedsAndPosts\ArticleData;
+use Wikia\FeedsAndPosts\ArticleTags;
 use Wikia\FeedsAndPosts\RecentChanges;
 use Wikia\FeedsAndPosts\ThemeSettings;
 use Wikia\FeedsAndPosts\TopArticles;
@@ -74,5 +75,22 @@ class FeedsAndPostsController extends WikiaApiController {
 			'snippet' => null,
 			'relativeUrl' => $title->getLocalURL(),
 		]);
+	}
+
+	public function getSuggestedTags() {
+		$this->response->setFormat( WikiaResponse::FORMAT_JSON );
+		$this->response->setCacheValidity( WikiaResponse::CACHE_STANDARD );
+		$this->response->setVal( 'tags', ( new ArticleTags() )->getSuggestedTags() );
+	}
+
+	public function searchForTags() {
+		$query = $this->request->getVal( 'query', '' );
+		if ( strlen( $query ) < 3 ) {
+			throw new BadRequestException( 'query param query query must be at least 3 characters' );
+		}
+
+		$this->response->setFormat( WikiaResponse::FORMAT_JSON );
+		$this->response->setCacheValidity( WikiaResponse::CACHE_LONG );
+		$this->response->setVal( 'tags', ( new ArticleTags() )->searchTags( $query ) );
 	}
 }


### PR DESCRIPTION
https://wikia-inc.atlassian.net/browse/IW-3673
https://github.com/Wikia/unified-platform/pull/2519

create dedicated endpoints in FeedsAndPosts controller for obtaining information about article tags.

@Wikia/iwing 