### PR TITLE
LinksUpdate: Don't wait on replicas in a remote DC

### DIFF
--- a/includes/LinksUpdate.php
+++ b/includes/LinksUpdate.php
@@ -490,15 +490,21 @@ class LinksUpdate {
 			}
 		}
 
+		$lb = wfGetLB();
+
 		foreach ( $deleteWheres as $deleteWhere ) {
 			$this->mDb->delete( $table, $deleteWhere, __METHOD__ );
-			wfWaitForSlaves();
+			$pos = $this->mDb->getMasterPos();
+
+			$lb->waitForAll( $pos, false );
 		}
 
 		$insertBatches = array_chunk( $insertions, $wgUpdateRowsPerQuery );
 		foreach ( $insertBatches as $insertBatch ) {
-			$this->mDb->insert( $table, $insertBatch, __METHOD__, 'IGNORE' );
-			wfWaitForSlaves();
+			$this->mDb->insert( $table, $insertBatch, __METHOD__, 'IGNORE' );;
+			$pos = $this->mDb->getMasterPos();
+
+			$lb->waitForAll( $pos, false );
 		}
 	}
 


### PR DESCRIPTION
The replication wait logic introduced in LinksUpdate will wait for replicas in
remote DCs as well to catch up, which causes undue delay in tasks processing. As
a compromise, let's only wait on replicas in the local DC instead, which should
still provide us without throttling while enabling fast processing.