### PR TITLE
helios: Gracefully handle the absence of client beacon ID

### DIFF
--- a/lib/Wikia/src/Service/Helios/HeliosClient.php
+++ b/lib/Wikia/src/Service/Helios/HeliosClient.php
@@ -289,10 +289,12 @@ class HeliosClient {
 			}
 			$responseBeacon = $this->getResponseHeader( 'x-client-beacon-id' )[0];
 
+			$wasUserIdMismatch = !$sessionUserId || $sessionUserId != $tokenInfo->user_id;
+			$wasBeaconIdMismatch = isset( $currentCtx['client_beacon_id'] ) && $currentCtx['client_beacon_id'] != $responseBeacon;
+
 			// check if Helios returned non-matching user_id. Sometimes it means user logged into a different account
 			// so we compare beacons as well just to be sure there was a mismatch
-			if ( ( empty( $sessionUserId ) || $sessionUserId != $tokenInfo->user_id ) &&
-				 $currentCtx['client_beacon_id'] != $responseBeacon ) {
+			if ( $wasUserIdMismatch && $wasBeaconIdMismatch ) {
 				// report an issue with the token mismatch
 				\Wikia\Logger\WikiaLogger::instance()->error(
 					'Helios beacon mismatch',


### PR DESCRIPTION
In 048411ea1331c504b58fd5f60e0eb820d309d88f, we have added an extra step of
comparing the beacon ID returned by helios to the beacon ID present in the
client request. However, the beacon ID may not be present in the request if it
was made to MediaWiki by a service rather than an user's browser directly, e.g.
a request by Feeds to its MediaWiki API controller.

This causes a PHP Notice due to the absent beacon ID that displays an HTML error
box on devboxes, causing responses to break. As a fix, only try to validate the
beacon ID if one was present in the request.