### PR TITLE
IW-3149 | Fix default og:image url

### DIFF
--- a/extensions/wikia/SEOTweaks/SEOTweaksHooksHelper.class.php
+++ b/extensions/wikia/SEOTweaks/SEOTweaksHooksHelper.class.php
@@ -151,8 +151,12 @@ class SEOTweaksHooksHelper {
 			if ( !empty( $imageUrl ) ) {
 				$meta['og:image'] = $imageUrl;
 			} else {
-				$meta['og:image'] = wfExpandUrl( $wgLogo );
+				$file = wfFindFile( Title::newFromText( 'Wiki.png', NS_FILE ) );
+				$meta['og:image'] = wfExpandUrl( $file->createThumb( 200, 200 ) );
 			}
+		} else {
+			$file = wfFindFile( Title::newFromText( 'Wiki.png', NS_FILE ) );
+			$meta['og:image'] = wfExpandUrl( $file->createThumb( 200, 200 ) );
 		}
 
 		return true;


### PR DESCRIPTION
In case of main pages and images without any image, the og:image meta tag should point to Wiki.png file. This was achieved by using wgLogo global variable, however it does not work if the wiki has no Wiki.png uploaded. In that case it should fall back to the fandom heart image (Wiki.png file from starter)
@Wikia/iwing 