### PR TITLE
DE-4995 | Removes second edit event being sent when redirect is left behind

### DIFF
--- a/extensions/wikia/DataWarehouse/DataWarehouseEventProducerController.class.php
+++ b/extensions/wikia/DataWarehouse/DataWarehouseEventProducerController.class.php
@@ -89,13 +89,6 @@ class DataWarehouseEventProducerController {
 			$oEventProducer->sendLog();
 		}
 
-		if ( !empty( $redirect_id ) ) {
-			$oEventProducer = new DataWarehouseEventProducer( 'edit' );
-			if ( $oEventProducer->buildMovePackage( $oOldTitle, $oUser, null, $redirect_id ) ) {
-				$oEventProducer->sendLog();
-			}
-		}
-
 		wfProfileOut( __METHOD__ );
 		return true;
 	}


### PR DESCRIPTION
In https://wikia-inc.atlassian.net/browse/DE-4995 we noticed that there are two events being sent for most page renames compared to UCP.

This is due to page rename DataWarehouse code causing two events edit to be sent.
One that's sent always, and another when redirect_id is not empty.

![image](https://user-images.githubusercontent.com/22835787/88317828-20b81480-cd1a-11ea-95ea-cd3bc08372b2.png)

Redirect_id is not empty when an redirect is left behind (selected by default when moving a page)