### PR TITLE
IW-4212 | Allow pages to be moved to the same title as a video

### DIFF
--- a/extensions/wikia/VideoHandlers/videoInfo/VideoInfoHooksHelper.class.php
+++ b/extensions/wikia/VideoHandlers/videoInfo/VideoInfoHooksHelper.class.php
@@ -111,7 +111,18 @@ class VideoInfoHooksHelper {
 	 * @param Title $newTitle
 	 * @return bool true
 	 */
-	public static function onFileRenameComplete( MovePageForm $form , Title &$oldTitle , Title &$newTitle ): bool {
+	public static function onFileRenameComplete( MovePageForm $form , Title $oldTitle , Title $newTitle ): bool {
+		// Nothing to do if the page being renamed is not a file at all (IW-4212)
+		if ( !$oldTitle->inNamespace( NS_FILE ) ) {
+			return true;
+		}
+
+		$file = wfFindFile( $oldTitle );
+
+		// Nothing to do if the page being renamed is not a video (IW-4212)
+		if ( !WikiaFileHelper::isVideoFile( $file ) ) {
+			return true;
+		}
 
 		$videoInfoHelper = new VideoInfoHelper();
 		$affected = $videoInfoHelper->renameVideo( $oldTitle, $newTitle );


### PR DESCRIPTION
The page rename hook handler registered by our VideoHandlers extension was
running for all page moves, not just for videos, causing an error when someone
tried to move a page to the same title as an existing video. As a solution, make
sure this handler only runs for video file renames.