### PR TITLE
PLATFORM-5064 | Fix shared file repos between UCP and App

### DIFF
--- a/extensions/wikia/WikiFactory/Loader/WikiFactoryLoader.php
+++ b/extensions/wikia/WikiFactory/Loader/WikiFactoryLoader.php
@@ -728,10 +728,12 @@ class WikiFactoryLoader {
 				unset( $this->mVariables[ 'wgSharedUploadDBname' ] );
 				unset( $this->mVariables[ 'wgUseSharedUploads' ] );
 
+				$url = rtrim( WikiFactory::getLocalEnvURL( $partnerWikiData->city_url ), '/' ) . '/api.php';
+
 				$this->mVariables['wgForeignFileRepos'][] = [
 					'name' => 'sharedUploadHack',
 					'class' => 'ForeignAPIRepo',
-					'apibase' => WikiFactory::getLocalEnvURL( $partnerWikiData->city_url ) . 'api.php',
+					'apibase' => $url,
 					'hashLevels' => 2,
 					'apiThumbCacheExpiry' => 0
 				];


### PR DESCRIPTION
## Links
*
* https://wikia-inc.atlassian.net/browse/PLATFORM-5064

## Description
WikiFactory::getLocalEnvURL for language path produces urls which ends with `/` but if there is no language it will remove it from end of the url.

@Wikia/core-platform-team 