### PR TITLE
PLATFORM-5079: enable mobile wiki performance monitoring

### DIFF
--- a/extensions/wikia/PerformanceMonitoring/PerformanceMonitoring.setup.php
+++ b/extensions/wikia/PerformanceMonitoring/PerformanceMonitoring.setup.php
@@ -1,0 +1,19 @@
+<?php
+/**
+ * Real User Monitoring
+ *
+ * @author wladek
+ */
+
+$wgExtensionCredits[ 'specialpage' ][ ] = array(
+	'name' => 'PerformanceMonitoring',
+	'author' => 'Fandom, Inc.',
+	'url' => 'https://github.com/Wikia/app/tree/dev/extensions/wikia/PerformanceMonitoring',
+);
+
+$dir = dirname(__FILE__) . '/';
+
+$wgAutoloadClasses['PerformanceMonitoringHooks'] =  $dir . 'PerformanceMonitoringHooks.class.php';
+
+$wgHooks['MercuryWikiVariables'][] = 'PerformanceMonitoringHooks::onMercuryWikiVariables';
+

--- a/extensions/wikia/PerformanceMonitoring/PerformanceMonitoring.setup.php
+++ b/extensions/wikia/PerformanceMonitoring/PerformanceMonitoring.setup.php
@@ -1,8 +1,6 @@
 <?php
 /**
  * Real User Monitoring
- *
- * @author wladek
  */
 
 $wgExtensionCredits[ 'specialpage' ][ ] = array(

--- a/extensions/wikia/PerformanceMonitoring/PerformanceMonitoringHooks.class.php
+++ b/extensions/wikia/PerformanceMonitoring/PerformanceMonitoringHooks.class.php
@@ -1,0 +1,32 @@
+<?php
+
+class PerformanceMonitoringHooks {
+
+	public static function onMercuryWikiVariables( array &$wikiVariables ): bool {
+		global $wgPerformanceMonitoringSamplingFactor;
+
+		$wikiVariables['wgPerformanceMonitoringSamplingFactor'] = $wgPerformanceMonitoringSamplingFactor;
+		$wikiVariables['wgPerformanceMonitoringSoftwareVersion'] = class_exists( 'WikiaSpecialVersion' ) ? (
+			WikiaSpecialVersion::getWikiaCodeVersion() ?? '' ) : '';
+		$wikiVariables['wgPerformanceMonitoringEndpointUrl'] = self::getViewTrackURL();
+
+		return true;
+	}
+
+	private static function getViewTrackURL(): string {
+		global $wgWikiaDatacenter, $wgWikiaEnvironment, $wgCityId, $wgContLang, $wgDBname, $wgUser,
+			   $wgPerformanceMonitoringBaseUrl;
+
+		$params = [
+			'w' => $wgCityId,
+			'lc' => $wgContLang->getCode(),
+			'd' => $wgDBname,
+			's' => 'mobilewiki',
+			'u' => ( $wgUser->isLoggedIn() ? 1 : 0 ),
+			'a' => '0',
+			'i' => getenv('HOSTNAME_OVERRIDE') ?? $wgWikiaDatacenter . '-' . $wgWikiaEnvironment,
+		];
+
+		return $wgPerformanceMonitoringBaseUrl . '/special/performance_metrics?' . http_build_query( $params );
+	}
+}

--- a/includes/wikia/DefaultSettings.php
+++ b/includes/wikia/DefaultSettings.php
@@ -1328,3 +1328,9 @@ $wgGcsConfig = [
 ];
 
 $wgThumblrUrl = 'https://thumblr-prod.c1.us-west1-a.gke.wikia.net';
+
+/**
+ * Define the base url and sampling factor for page loads for performance monitoring.
+ */
+$wgPerformanceMonitoringBaseUrl = 'https://beacon.wikia-services.com/__track';
+$wgPerformanceMonitoringSamplingFactor = 100; // sample 1/100 of requests

--- a/includes/wikia/Extensions.php
+++ b/includes/wikia/Extensions.php
@@ -1820,4 +1820,6 @@ if ( $wgEnableArticleCommentsExt || $wgEnableWallExt || $wgEnableDiscussions ) {
 
 include_once "$IP/extensions/wikia/WikiDescription/WikiDescription.setup.php";
 
+include_once "$IP/extensions/wikia/PerformanceMonitoring/PerformanceMonitoring.setup.php";
+
 $wgUCPCommunityCNWAddress = 'https://ucp.fandom.com/wiki/Special:CreateNewWiki';


### PR DESCRIPTION
Expose RUM setup variables to mobile-wiki so it starts reporting the metrics.
config change: https://github.com/Wikia/config/pull/2568