### PR TITLE
IW-4208 | Don't save theme settings if image dimensions were not set

### DIFF
--- a/extensions/wikia/SASS/SassUtil.php
+++ b/extensions/wikia/SASS/SassUtil.php
@@ -96,15 +96,6 @@ class SassUtil {
 
 					$settings['background-image-width'] = static::$oasisSettings['background-image-width'] = $bgImage->getWidth();
 					$settings['background-image-height'] = static::$oasisSettings['background-image-height'] = $bgImage->getHeight();
-
-					// SUS-3104: Do not run this in the context of the session user
-					$globalStateWrapper = new Wikia\Util\GlobalStateWrapper( [
-						'wgUser' => User::newFromName( Wikia::BOT_USER, false )
-					] );
-
-					$globalStateWrapper->wrap( function () use ( $themeSettings, $settings ) {
-						$themeSettings->saveSettings( $settings );
-					} );
 				}
 			}
 


### PR DESCRIPTION
In certain situations, app code may end up being invoked in an UCP context.
Don't try to save theme settings in this scenario (if image dimensions are
missing), as it may save an older version of the settings than the one that's
live on the new platform.

@Wikia/iwing 