### PR TITLE
IW-3045 | Remove backslash from the end of shortened value

### DIFF
--- a/extensions/wikia/Discussions/maintenance/DumpUtils.php
+++ b/extensions/wikia/Discussions/maintenance/DumpUtils.php
@@ -35,7 +35,7 @@ class DumpUtils {
 					$dbValue = mb_strcut( $dbValue, 0, DumpUtils::MAX_CONTENT_SIZE );
 				}
 
-				$insert .= ', ' . "'" . $dbValue . "'";
+				$insert .= ', ' . "'" . rtrim( $dbValue, '\\' ) . "'";
 			} else {
 				$insert .= ', ' . $db->addQuotes( $value );
 			}


### PR DESCRIPTION
@Wikia/iwing 

Sometimes when forum dump script cut long content - it leaves backslash as a last character. It is not acceptable, as it makes sql statement invalid.