### PR TITLE
cake-5810 | Remove set width

### DIFF
--- a/extensions/wikia/UserProfilePageV3/css/UserProfilePage.scss
+++ b/extensions/wikia/UserProfilePageV3/css/UserProfilePage.scss
@@ -296,7 +296,6 @@ $color-user-profile-gradient-bottom: desaturate(darken($color-menu-highlight, 5%
 				.wds-dropdown__content {
 					padding: 6px;
 					text-align: center;
-					width: 150px;
 				}
 			}
 		}


### PR DESCRIPTION
This prevents usernames from spilling out over the set width of 150px.