### PR TITLE
CAKE-5704 Display user talk notifications from unified-platform wikis

### DIFF
--- a/extensions/wikia/DesignSystem/i18n/en.json
+++ b/extensions/wikia/DesignSystem/i18n/en.json
@@ -97,6 +97,7 @@
   "notifications-own-wall-reply": "{user} <b>replied</b> to a message on your wall <br><br> {postTitle}",
   "notifications-own-wall-reply-multiple-users": "{user} and {number} other users <b>replied</b> to a message on your wall <br><br> {postTitle}",
   "notifications-own-wall-post-removed": "<b>Message removed</b> from your wall <br><br> {postTitle}",
+  "notifications-user-talk-message": "{user} left a <b>new message</b> on your talk page",
   "notifications-wall-post-removed": "<b>Message removed</b> from {user}'s wall <br><br> {postTitle}",
   "notifications-wall-post": "{firstUser} left a <b>new message</b> on {secondUser}'s wall <br><br> {postTitle}",
   "notifications-wall-reply": "{firstUser} <b>replied</b> to {secondUser}'s message <br><br> {postTitle}",

--- a/extensions/wikia/DesignSystem/i18n/en.json
+++ b/extensions/wikia/DesignSystem/i18n/en.json
@@ -97,7 +97,7 @@
   "notifications-own-wall-reply": "{user} <b>replied</b> to a message on your wall <br><br> {postTitle}",
   "notifications-own-wall-reply-multiple-users": "{user} and {number} other users <b>replied</b> to a message on your wall <br><br> {postTitle}",
   "notifications-own-wall-post-removed": "<b>Message removed</b> from your wall <br><br> {postTitle}",
-  "notifications-user-talk-message": "{user} left a <b>new message</b> on your talk page",
+  "notifications-talk-page-message": "{user} left a <b>new message</b> on your talk page",
   "notifications-wall-post-removed": "<b>Message removed</b> from {user}'s wall <br><br> {postTitle}",
   "notifications-wall-post": "{firstUser} left a <b>new message</b> on {secondUser}'s wall <br><br> {postTitle}",
   "notifications-wall-reply": "{firstUser} <b>replied</b> to {secondUser}'s message <br><br> {postTitle}",

--- a/extensions/wikia/DesignSystem/scripts/DesignSystemGlobalNavigationOnSiteNotifications.common.js
+++ b/extensions/wikia/DesignSystem/scripts/DesignSystemGlobalNavigationOnSiteNotifications.common.js
@@ -7,7 +7,8 @@ define('ext.wikia.design-system.on-site-notifications.common', [], function () {
 			discussionReply: 'discussion-reply',
 			announcement: 'announcement',
 			postAtMention: 'post-at-mention',
-			threadAtMention: 'thread-at-mention'
+			threadAtMention: 'thread-at-mention',
+			talkPageMessage: 'talk-page-message'
 		}, logTag = 'on-site-notifications';
 
 		return {

--- a/extensions/wikia/DesignSystem/scripts/DesignSystemGlobalNavigationOnSiteNotifications.text-formatter.js
+++ b/extensions/wikia/DesignSystem/scripts/DesignSystemGlobalNavigationOnSiteNotifications.text-formatter.js
@@ -135,7 +135,7 @@ define('ext.wikia.design-system.on-site-notifications.text-formatter', [
 			};
 
 			this._getTalkPageMessageText = function (notification) {
-				return fillArgs(getMessage('notifications-talk-page-message'), args = {
+				return fillArgs(getMessage('notifications-talk-page-message'), {
 					user: escape(notification.latestActors[0].name),
 				});
 			};

--- a/extensions/wikia/DesignSystem/scripts/DesignSystemGlobalNavigationOnSiteNotifications.text-formatter.js
+++ b/extensions/wikia/DesignSystem/scripts/DesignSystemGlobalNavigationOnSiteNotifications.text-formatter.js
@@ -37,6 +37,8 @@ define('ext.wikia.design-system.on-site-notifications.text-formatter', [
 					return this._getThreadAtMentionText(notification)
 				} else if (notification.type === c.notificationTypes.postAtMention) {
 					return this._getPostAtMentionText(notification)
+				} else if (notification.type = c.notificationTypes.talkPageMessage) {
+					return this._getTalkPageMessageText(notification);
 				} else {
 					return notification.title;
 				}
@@ -130,6 +132,12 @@ define('ext.wikia.design-system.on-site-notifications.text-formatter', [
 				return title ?
 					'notifications-reply-upvote-multiple-users-with-title' :
 					'notifications-reply-upvote-multiple-users-no-title';
+			};
+
+			this._getTalkPageMessageText = function (notification) {
+				return fillArgs(getMessage('notifications-talk-page-message'), args = {
+					user: escape(notification.latestActors[0].name),
+				});
 			};
 		}
 

--- a/extensions/wikia/DesignSystem/scripts/DesignSystemGlobalNavigationOnSiteNotifications.text-formatter.js
+++ b/extensions/wikia/DesignSystem/scripts/DesignSystemGlobalNavigationOnSiteNotifications.text-formatter.js
@@ -135,8 +135,11 @@ define('ext.wikia.design-system.on-site-notifications.text-formatter', [
 			};
 
 			this._getTalkPageMessageText = function (notification) {
+				var userName = ( notification.latestActors[0] && notification.latestActors[0].name ) ?
+					escape(notification.latestActors[0].name) :
+					getMessage('oasis-anon-user');
 				return fillArgs(getMessage('notifications-talk-page-message'), {
-					user: escape(notification.latestActors[0].name),
+					user: userName,
 				});
 			};
 		}

--- a/extensions/wikia/DesignSystem/scripts/DesignSystemGlobalNavigationOnSiteNotifications.view.js
+++ b/extensions/wikia/DesignSystem/scripts/DesignSystemGlobalNavigationOnSiteNotifications.view.js
@@ -118,6 +118,8 @@ define('ext.wikia.design-system.on-site-notifications.view', [
 						return 'wds-icons-comment-small';
 					} else if (type === common.notificationTypes.announcement) {
 						return 'wds-icons-flag-small';
+					} else if (type === common.notificationTypes.talkPageMessage) {
+						return 'wds-icons-bubble-small';
 					} else {
 						return 'wds-icons-heart-small';
 					}


### PR DESCRIPTION
This will handle user talk notifications created on the unified-platform, which still need to display on the old app.