### PR TITLE
IW-4418 | add link to Wikimedia:Commons source for hotlinked images for anon users

### DIFF
--- a/extensions/wikia/Lightbox/LightboxController.class.php
+++ b/extensions/wikia/Lightbox/LightboxController.class.php
@@ -217,6 +217,7 @@ class LightboxController extends WikiaController {
 		$this->exists = $data['exists'];
 		$this->isAdded = $data['isAdded'];
 		$this->extraHeight = $data['extraHeight'];
+		$this->externalUrl = $data['externalUrl'];
 		$this->isUserAnon = $this->wg->User->isAnon();
 		$parserOptions = new ParserOptions();
 		$parserOptions->setEditSection( false );

--- a/extensions/wikia/Lightbox/templates/Lightbox_lightboxModalContent.php
+++ b/extensions/wikia/Lightbox/templates/Lightbox_lightboxModalContent.php
@@ -54,6 +54,14 @@
 			</div>
 		</div>
 		{{/imageDescription}}
+		{{^imageDescription}}
+			{{#externalUrl}}
+			<a href="{{externalUrl}}" class="more-info-button wds-button wds-is-secondary">
+				<?= DesignSystemHelper::renderSvg( 'wds-icons-question', 'wds-icon wds-icon-small' ); ?>
+				<span><?= wfMessage( 'lightbox-header-more-info-button' )->escaped() ?></span>
+			</a>
+			{{/externalUrl}}
+		{{/imageDescription}}
 		{{/isUserAnon}}
 		{{^isUserAnon}}
 		<a href="{{fileUrl}}" class="wikia-button more-info-button secondary"><?= wfMessage('lightbox-header-more-info-button')->escaped() ?></a>

--- a/extensions/wikia/Lightbox/templates/Lightbox_lightboxModalContent.php
+++ b/extensions/wikia/Lightbox/templates/Lightbox_lightboxModalContent.php
@@ -56,9 +56,8 @@
 		{{/imageDescription}}
 		{{^imageDescription}}
 			{{#externalUrl}}
-			<a href="{{externalUrl}}" class="more-info-button wds-button wds-is-secondary">
-				<?= DesignSystemHelper::renderSvg( 'wds-icons-question', 'wds-icon wds-icon-small' ); ?>
-				<span><?= wfMessage( 'lightbox-header-more-info-button' )->escaped() ?></span>
+			<a href="{{externalUrl}}" class="wikia-button more-info-button secondary">
+				<?= wfMessage('lightbox-header-more-info-button')->escaped() ?>
 			</a>
 			{{/externalUrl}}
 		{{/imageDescription}}

--- a/includes/wikia/services/WikiaFileHelper.class.php
+++ b/includes/wikia/services/WikiaFileHelper.class.php
@@ -270,6 +270,7 @@ class WikiaFileHelper {
 			'exists' => false,
 			'isAdded' => true,
 			'extraHeight' => 0,
+			'externalUrl' => '',
 		);
 
 		if ( !empty( $fileTitle ) ) {
@@ -330,6 +331,11 @@ class WikiaFileHelper {
 				$data['articles'] = $articleList;
 				$data['width'] = $width;
 				$data['height'] = $height;
+
+				// this covers eg. images added via InstantCommons
+				if ( !$file->isLocal() ) {
+					$data['externalUrl'] = $file->getDescriptionUrl();
+				}
 			}
 		}
 


### PR DESCRIPTION
## Links
* http://wikia-inc.atlassian.net/browse/IW-4418

## Description
Anon users were not able to check the source of image because our file pages are blocked for them. Normally we display a popover with licence and stuff but for InstantCommons the content was too obfuscated to display so to bypass it let's link "More info" button with the original Wikimedia Commons source page.

@Wikia/iwing 