### PR TITLE
SER-4295 Increase Phalanx timeout

### DIFF
--- a/extensions/wikia/PhalanxII/services/DesperatePhalanxService.php
+++ b/extensions/wikia/PhalanxII/services/DesperatePhalanxService.php
@@ -5,8 +5,7 @@
  * if they fail before giving up.
  */
 class DesperatePhalanxService implements PhalanxService {
-	const RETRY_COUNT = 3;
-	const DELAY_BETWEEN_RETRIES = 20000;
+	const RETRY_COUNT = 2;
 
 	/** @var PhalanxService $phalanxService */
 	private $phalanxService;
@@ -28,12 +27,10 @@ class DesperatePhalanxService implements PhalanxService {
 		try {
 			return $this->phalanxService->doMatch( $phalanxMatchParams );
 		} catch ( PhalanxServiceException $phalanxServiceException ) {
-			if ( ++$retryCount > static::RETRY_COUNT ) {
+			if ( $retryCount >= static::RETRY_COUNT ) {
 				throw $phalanxServiceException;
 			}
-
-			usleep( static::DELAY_BETWEEN_RETRIES );
-			return $this->doMatchWithRetries( $phalanxMatchParams, $retryCount );
+			return $this->doMatchWithRetries( $phalanxMatchParams, $retryCount + 1 );
 		}
 	}
 
@@ -51,12 +48,11 @@ class DesperatePhalanxService implements PhalanxService {
 		try {
 			return $this->phalanxService->doRegexValidation( $regex );
 		} catch ( PhalanxServiceException $phalanxServiceException ) {
-			if ( ++$retryCount > static::RETRY_COUNT ) {
+			if ( $retryCount >= static::RETRY_COUNT ) {
 				throw $phalanxServiceException;
 			}
 
-			usleep( static::DELAY_BETWEEN_RETRIES );
-			return $this->doRegexValidationWithRetries( $regex, $retryCount );
+			return $this->doRegexValidationWithRetries( $regex, $retryCount + 1 );
 		}
 	}
 }

--- a/includes/wikia/DefaultSettings.php
+++ b/includes/wikia/DefaultSettings.php
@@ -960,7 +960,8 @@ $wgWAMPageConfig = array(
 $wgPhalanxService = true;
 $wgPhalanxServiceOptions = [
 	'noProxy' => true, # PLATFORM-1744: do not use the default HTTP proxy (defined in $wgHTTPProxy) for Phalanx requests
-	'timeout' => 2, # [sec] PLATFORM-2385 / SUS-890: prevent Phalanx slowness from affecting the site performance
+	'timeout' => 3, # [sec] PLATFORM-2385 / SUS-890 / SER-4295: prevent Phalanx slowness from affecting the site
+	# performance
 	'internalRequest' => true
 ];
 

--- a/includes/wikia/DefaultSettings.php
+++ b/includes/wikia/DefaultSettings.php
@@ -960,7 +960,7 @@ $wgWAMPageConfig = array(
 $wgPhalanxService = true;
 $wgPhalanxServiceOptions = [
 	'noProxy' => true, # PLATFORM-1744: do not use the default HTTP proxy (defined in $wgHTTPProxy) for Phalanx requests
-	'timeout' => 1, # [sec] PLATFORM-2385 / SUS-890: prevent Phalanx slowness from affecting the site performance
+	'timeout' => 2, # [sec] PLATFORM-2385 / SUS-890: prevent Phalanx slowness from affecting the site performance
 	'internalRequest' => true
 ];
 

--- a/includes/wikia/DefaultSettings.php
+++ b/includes/wikia/DefaultSettings.php
@@ -960,7 +960,7 @@ $wgWAMPageConfig = array(
 $wgPhalanxService = true;
 $wgPhalanxServiceOptions = [
 	'noProxy' => true, # PLATFORM-1744: do not use the default HTTP proxy (defined in $wgHTTPProxy) for Phalanx requests
-	'timeout' => 1, # [sec] PLATFORM-2385 / SUS-890: prevent Phalanx slowness from affecting the site performance
+	'timeout' => 2.0, # [sec] PLATFORM-2385 / SUS-890: prevent Phalanx slowness from affecting the site performance
 	'internalRequest' => true
 ];
 


### PR DESCRIPTION
Increase the timeout from 1s to 2s while removing the delay between requests and reducing the number of retries from 3 to 2.