### PR TITLE
IW-4463 | Return null instead of empty array for LocalNav items

### DIFF
--- a/includes/wikia/models/DesignSystemCommunityHeaderModel.class.php
+++ b/includes/wikia/models/DesignSystemCommunityHeaderModel.class.php
@@ -401,7 +401,7 @@ class DesignSystemCommunityHeaderModel extends WikiaModel {
 								'href' => $item[ 'url' ],
 								'tracking_label' => $item[ 'tracking' ],
 							];
-						}, $item[ 'items' ] ) : [],
+						}, $item[ 'items' ] ) : null,
 					];
 				}, array_values( array_filter( $exploreItems, function ( $item ) {
 					return $item[ 'include' ];


### PR DESCRIPTION
@Wikia/iwing @Wikia/cake 

P2 caused by https://github.com/Wikia/app/pull/18153