### PR TITLE
GPUCP-551 | Use correct hosts for c9 cluster

### DIFF
--- a/includes/wikia/VariablesExpansions.php
+++ b/includes/wikia/VariablesExpansions.php
@@ -304,9 +304,10 @@ $wgLBFactoryConf = [
             'geo-db-h-master.query.consul' => 0,
             'geo-db-h-slave.query.consul' => 1000,
         ],
-		'c9' => [
-			'ucp-dbmigration-s1' => 0,
-		],
+        'c9' => [
+            'geo-db-i-master.query.consul' => 0,
+            'geo-db-i-slave.query.consul' => 1000,
+        ],
 
         'ext1' => $wgDBArchiveCluster,
         'specials' => [


### PR DESCRIPTION
This will fix API errors getting wiki details, since that service
needs to query the site_stats table of the wiki.

https://wikia-inc.atlassian.net/browse/GPUCP-551
