### PR TITLE
PLATFORM-5168 | Use FQDN for consul external services to lower number of DNS NXDOMAIN requests

### DIFF
--- a/includes/wikia/VariablesBase.php
+++ b/includes/wikia/VariablesBase.php
@@ -746,8 +746,8 @@ $wgBiggestCategoriesBlacklist = [
  * @var Array $wgBlobs001Cluster
  */
 $wgBlobs001Cluster = [
-	'geo-db-blobs-a-master.query.consul' => 0,
-	'geo-db-blobs-a-slave.query.consul' => 1000
+	'geo-db-blobs-a-master.query.consul.' => 0,
+	'geo-db-blobs-a-slave.query.consul.' => 1000
 ];
 
 /**
@@ -1312,8 +1312,8 @@ $wgDBAhandler = 'db3';
  * @var Array $wgDBArchiveCluster
  */
 $wgDBArchiveCluster = [
-	'geo-db-archive-master.query.consul' => 0,
-	'geo-db-archive-slave.query.consul' => 1000
+	'geo-db-archive-master.query.consul.' => 0,
+	'geo-db-archive-slave.query.consul.' => 1000
 ];
 
 /**
@@ -5948,8 +5948,8 @@ $wgMemCachedPersistent = true;
  * @var Array $wgMemCachedServers
  */
 $wgMemCachedServers = [
-	0 => 'prod.twemproxy.service.consul:21000',
-	1 => 'prod.twemproxy.service.consul:31000',
+	0 => 'prod.twemproxy.service.consul.:21000',
+	1 => 'prod.twemproxy.service.consul.:31000',
 ];
 
 /**
@@ -6699,7 +6699,7 @@ $wgQueryPageDefaultLimit = 50;
  * Hostname of the datacenter-local Rabbit cluster.
  * @var string $wgRabbitHost
  */
-$wgRabbitHost = 'prod.rabbit.service.consul';
+$wgRabbitHost = 'prod.rabbit.service.consul.';
 
 /**
  * Port used by the datacenter-local Rabbit cluster.
@@ -7292,8 +7292,8 @@ $wgSessionHandler = null;
  * @var Array $wgSessionMemCachedServers
  */
 $wgSessionMemCachedServers = [
-	0 => 'prod.twemproxy.service.consul:31001',
-	1 => 'prod.twemproxy.service.consul:21001',
+	0 => 'prod.twemproxy.service.consul.:31001',
+	1 => 'prod.twemproxy.service.consul.:21001',
 ];
 
 /**
@@ -7580,7 +7580,7 @@ $wgSortSpecialPages = true;
  * @var Array $wgSMTP
  */
 $wgSMTP = [
-	'host'   => 'prod.smtp.service.consul',
+	'host'   => 'prod.smtp.service.consul.',
 	'port'   => 25,
 	'auth'   => false,
 	'IDHost' => ''
@@ -7592,7 +7592,7 @@ $wgSMTP = [
  * @see extensions/wikia/Search
  * @var string $wgSolrHost
  */
-$wgSolrHost = 'prod.search-fulltext.service.consul';
+$wgSolrHost = 'prod.search-fulltext.service.consul.';
 
 
 /**
@@ -7600,7 +7600,7 @@ $wgSolrHost = 'prod.search-fulltext.service.consul';
  * @see includes/wikia/services/ArticleService.class.php
  * @var string $wgSolrKvHost
  */
-$wgSolrKvHost = 'prod.search-kv.service.consul';
+$wgSolrKvHost = 'prod.search-kv.service.consul.';
 
 
 /**
@@ -9090,7 +9090,7 @@ $wgCircuitBreakerType = 'noop';
  * @see lib/Wikia/src/CircuitBreaker/RedisCircuitBreakerStorage.php
  * @var string $wgCircuitBreakerRedisHost
  */
-$wgCircuitBreakerRedisHost = 'geo-redisshared-prod-master.query.consul';
+$wgCircuitBreakerRedisHost = 'geo-redisshared-prod-master.query.consul.';
 
 
 /**

--- a/includes/wikia/VariablesExpansions.php
+++ b/includes/wikia/VariablesExpansions.php
@@ -273,58 +273,58 @@ $wgLBFactoryConf = [
     ],
     'sectionLoads' => [
         'c1' => [
-            'geo-db-a-master.query.consul' => 0,
-            'geo-db-a-slave.query.consul' => 1000,
+            'geo-db-a-master.query.consul.' => 0,
+            'geo-db-a-slave.query.consul.' => 1000,
         ],
         'c2' => [
-            'geo-db-b-master.query.consul' => 0,
-            'geo-db-b-slave.query.consul' => 1000,
+            'geo-db-b-master.query.consul.' => 0,
+            'geo-db-b-slave.query.consul.' => 1000,
         ],
         'c3' => [
-            'geo-db-c-master.query.consul' => 0,
-            'geo-db-c-slave.query.consul' => 1000,
+            'geo-db-c-master.query.consul.' => 0,
+            'geo-db-c-slave.query.consul.' => 1000,
         ],
         'c4' => [
-            'geo-db-d-master.query.consul' => 0,
-            'geo-db-d-slave.query.consul' => 1000,
+            'geo-db-d-master.query.consul.' => 0,
+            'geo-db-d-slave.query.consul.' => 1000,
         ],
         'c5' => [
-            'geo-db-e-master.query.consul' => 0,
-            'geo-db-e-slave.query.consul' => 1000,
+            'geo-db-e-master.query.consul.' => 0,
+            'geo-db-e-slave.query.consul.' => 1000,
         ],
         'c6' => [
-            'geo-db-f-master.query.consul' => 0,
-            'geo-db-f-slave.query.consul' => 1000,
+            'geo-db-f-master.query.consul.' => 0,
+            'geo-db-f-slave.query.consul.' => 1000,
         ],
         'c7' => [
-            'geo-db-g-master.query.consul' => 0,
-            'geo-db-g-slave.query.consul' => 1000,
+            'geo-db-g-master.query.consul.' => 0,
+            'geo-db-g-slave.query.consul.' => 1000,
         ],
         'c8' => [
-            'geo-db-h-master.query.consul' => 0,
-            'geo-db-h-slave.query.consul' => 1000,
+            'geo-db-h-master.query.consul.' => 0,
+            'geo-db-h-slave.query.consul.' => 1000,
         ],
         'c9' => [
-            'geo-db-i-master.query.consul' => 0,
-            'geo-db-i-slave.query.consul' => 1000,
+            'geo-db-i-master.query.consul.' => 0,
+            'geo-db-i-slave.query.consul.' => 1000,
         ],
 
         'ext1' => $wgDBArchiveCluster,
         'specials' => [
-            'geo-db-specials-master.query.consul' => 0,
-            'geo-db-specials-slave.query.consul' => 1000,
+            'geo-db-specials-master.query.consul.' => 0,
+            'geo-db-specials-slave.query.consul.' => 1000,
         ],
         'datawarehouse' => [
-            'geo-db-dataware-master.query.consul' => 0,
-            'geo-db-dataware-slave.query.consul' => 1000,
+            'geo-db-dataware-master.query.consul.' => 0,
+            'geo-db-dataware-slave.query.consul.' => 1000,
         ],
         'semanticdb' => [
-            'geo-db-smw-master.query.consul' => 0,
-            'geo-db-smw-slave.query.consul' => 1000,
+            'geo-db-smw-master.query.consul.' => 0,
+            'geo-db-smw-slave.query.consul.' => 1000,
         ],
         'central' => [
-            'geo-db-sharedb-master.query.consul' => 0,
-            'geo-db-sharedb-slave.query.consul'	=> 1000,
+            'geo-db-sharedb-master.query.consul.' => 0,
+            'geo-db-sharedb-slave.query.consul.'	=> 1000,
         ],
         'blobs001' => $wgBlobs001Cluster,
     ],
@@ -369,7 +369,7 @@ $wgLyricsApiSolrariumConfig = [
     'adapter' => 'Solarium_Client_Adapter_Curl',
     'adapteroptions' => [
         'core' => 'lyricsapi',
-        'host' => 'prod.search-fulltext.service.consul',
+        'host' => 'prod.search-fulltext.service.consul.',
         'path' => '/solr/',
         'port' => $wgSolrPort,
         'proxy' => false,

--- a/lib/Wikia/src/Consul/Client.php
+++ b/lib/Wikia/src/Consul/Client.php
@@ -96,7 +96,7 @@ class Client {
 	 * Helper method for getting IP addresses of all nodes hidden behind consul
 	 *
 	 * $consul->getNodesFromHostname( 'slave.db-smw.service.consul' )
-	 * $consul->getNodesFromHostname( 'geo-db-g-slave.query.consul' )
+	 * $consul->getNodesFromHostname( 'geo-db-g-slave.query.consul.' )
 	 *
 	 * @param string $hostname
 	 * @return array list of IP addresses
@@ -106,7 +106,7 @@ class Client {
 		Assert::true( self::isConsulAddress( $hostname ), __METHOD__ . ' should get a Consul address', $this->getLoggerContext() );
 
 		if ( self::isConsulQuery($hostname) ) {
-			// e.g. geo-db-g-slave.query.consul
+			// e.g. geo-db-g-slave.query.consul.
 			$query = self::parseConsulQuery( $hostname );
 			return $this->getNodesFromConsulQuery( $query );
 		}
@@ -135,7 +135,7 @@ class Client {
 	 * @return string
 	 */
 	static function getConsulBaseUrl() : string {
-		return sprintf( 'http://consul.service.consul:8500' );
+		return sprintf( 'http://consul.service.consul.:8500' );
 	}
 
 	/**
@@ -145,27 +145,29 @@ class Client {
 	 * @return string
 	 */
 	static function getConsulBaseUrlForDC( string $dc ) : string {
-		return sprintf( 'http://consul.service.%s.consul:8500', $dc );
+		return sprintf( 'http://consul.service.%s.consul.:8500', $dc );
 	}
 
 	/**
 	 * Example: Wikia\Consul\Client::isConsulAddress( 'slave.db-smw.service.consul' )
+	 * Example: Wikia\Consul\Client::isConsulAddress( 'slave.db-smw.service.consul.' )
 	 *
 	 * @param string $address
 	 * @return bool true if the given address is a consul one
 	 */
 	static function isConsulAddress( string $address ) : bool {
-		return endsWith( $address, '.consul' );
+		return endsWith( $address, '.consul' ) || endsWith( $address, '.consul.' );
 	}
 
 	/**
 	 * Example: Wikia\Consul\Client::isConsulServiceAddress( 'slave.db-smw.service.consul' )
+	 * Example: Wikia\Consul\Client::isConsulServiceAddress( 'slave.db-smw.service.consul.' )
 	 *
 	 * @param string $address
 	 * @return bool true if the given address is a consul service one
 	 */
 	static function isConsulServiceAddress( string $address ) : bool {
-		return endsWith( $address, '.service.consul' );
+		return endsWith( $address, '.service.consul' ) || endsWith( $address, '.service.consul.' );
 	}
 
 	/**
@@ -188,6 +190,7 @@ class Client {
 
 	/**
 	 * Example: Wikia\Consul\Client::isConsulQuery( 'geo-db-g-slave.query.consul' )
+	 * Example: Wikia\Consul\Client::isConsulQuery( 'geo-db-h-slave.query.consul.' )
 	 *
 	 * @see https://www.consul.io/api/query.html
 	 *
@@ -195,7 +198,7 @@ class Client {
 	 * @return bool true if the given address is a consul query
 	 */
 	static function isConsulQuery( string $address ) : bool {
-		return endsWith( $address, '.query.consul' );
+		return endsWith( $address, '.query.consul' ) || endsWith( $address, '.query.consul.' );
 	}
 
 	/**

--- a/lib/Wikia/tests/Consul/ClientTest.php
+++ b/lib/Wikia/tests/Consul/ClientTest.php
@@ -11,15 +11,16 @@ use Wikia\Consul\Client;
 class ConsulClientTest extends WikiaBaseTest {
 
 	function testGetConsulBaseUrlForDC() {
-		$this->assertEquals( 'http://consul.service.sjc.consul:8500', Client::getConsulBaseUrlForDC( 'sjc' ) );
-		$this->assertEquals( 'http://consul.service.sjc-dev.consul:8500', Client::getConsulBaseUrlForDC( 'sjc-dev' ) );
-		$this->assertEquals( 'http://consul.service.res.consul:8500', Client::getConsulBaseUrlForDC( 'res' ) );
+		$this->assertEquals( 'http://consul.service.sjc.consul.:8500', Client::getConsulBaseUrlForDC( 'sjc' ) );
+		$this->assertEquals( 'http://consul.service.sjc-dev.consul.:8500', Client::getConsulBaseUrlForDC( 'sjc-dev' ) );
+		$this->assertEquals( 'http://consul.service.res.consul.:8500', Client::getConsulBaseUrlForDC( 'res' ) );
 	}
 
 	function testIsConsulAddress() {
 		$this->assertTrue( Client::isConsulAddress( 'slave.db-smw.service.consul' ) );
 		$this->assertTrue( Client::isConsulAddress( 'master.db-a.service.consul' ) );
 		$this->assertTrue( Client::isConsulAddress( 'geo-db-sharedb-master.query.consul' ) );
+		$this->assertTrue( Client::isConsulAddress( 'geo-db-a-slave.query.consul.' ) );
 
 		$this->assertFalse( Client::isConsulAddress( 'statsdb-s9' ) );
 	}
@@ -27,9 +28,11 @@ class ConsulClientTest extends WikiaBaseTest {
 	function testIsConsulServiceAddress() {
 		$this->assertTrue( Client::isConsulServiceAddress( 'master.db-a.service.consul' ) );
 		$this->assertTrue( Client::isConsulServiceAddress( 'slave.db-smw.service.consul' ) );
+		$this->assertTrue( Client::isConsulServiceAddress( 'slave.db-smw.service.consul.' ) );
 
 		$this->assertFalse( Client::isConsulServiceAddress( 'geo-db-sharedb-master.query.consul' ) );
 		$this->assertFalse( Client::isConsulServiceAddress( 'geo-db-g-slave.query.consul' ) );
+		$this->assertFalse( Client::isConsulServiceAddress( 'geo-db-a-slave.query.consul.' ) );
 
 		$this->assertFalse( Client::isConsulServiceAddress( 'statsdb-s9' ) );
 	}
@@ -37,8 +40,10 @@ class ConsulClientTest extends WikiaBaseTest {
 	function testIsConsulQuery() {
 		$this->assertTrue( Client::isConsulQuery( 'geo-db-sharedb-master.query.consul' ) );
 		$this->assertTrue( Client::isConsulQuery( 'geo-db-g-slave.query.consul' ) );
+		$this->assertTrue( Client::isConsulQuery( 'geo-db-a-slave.query.consul.' ) );
 
 		$this->assertFalse( Client::isConsulQuery( 'slave.db-smw.service.consul' ) );
+		$this->assertFalse( Client::isConsulQuery( 'slave.db-smw.service.consul.' ) );
 		$this->assertFalse( Client::isConsulQuery( 'master.db-a.service.consul' ) );
 		$this->assertFalse( Client::isConsulQuery( 'statsdb-s9' ) );
 	}


### PR DESCRIPTION
We use those domain names on UCP, which significantly lower usage of local DNS server. Left possibility of use for urls without `.` at the end if some urls weren't changed.