### PR TITLE
PLATFORM-5091 | Allow to set SMW external cluster DB Name

### DIFF
--- a/extensions/SemanticMediaWiki/src/MediaWiki/LazyDBConnectionProvider.php
+++ b/extensions/SemanticMediaWiki/src/MediaWiki/LazyDBConnectionProvider.php
@@ -52,13 +52,13 @@ class LazyDBConnectionProvider implements DBConnectionProvider {
 
 		// Wikia change - begin
 		// moved here from wfGetDB()
-		global $smwgUseExternalDB, $wgDBname;
+		global $smwgUseExternalDB, $wgDBname, $smwgExternalDBName;
 
 		if ( $groups === self::SMW_GROUP && $smwgUseExternalDB === true ) {
 			if ( $wiki === false ) {
 				$wiki = $wgDBname;
 			}
-			$this->wiki = "smw+" . $wiki;
+			$this->wiki = !empty( $smwgExternalDBName ) ? $smwgExternalDBName : "smw+" . $wiki;
 			$this->groups = 'smw';
 			wfDebug( __METHOD__ . ": smw+ cluster is active, requesting $wiki\n" );
 		}

--- a/includes/GlobalFunctions.php
+++ b/includes/GlobalFunctions.php
@@ -3604,13 +3604,13 @@ function wfSplitWikiID( $wiki ) {
  */
 function &wfGetDB( int $db, $groups = array(), $wiki = false ) {
 	// wikia change begin -- SMW DB separation project, @author Krzysztof Krzyżaniak (eloy)
-	global $smwgUseExternalDB, $wgDBname;
+	global $smwgUseExternalDB, $wgDBname, $smwgExternalDBName;;
 	if( $smwgUseExternalDB === true ) {
 		if( ( is_array( $groups ) && in_array( 'smw', $groups ) ) || $groups === 'smw' ) {
 			if( $wiki === false ) {
 				$wiki = $wgDBname;
 			}
-			$wiki = "smw+" . $wiki;
+			$wiki = !empty( $smwgExternalDBName ) ? $smwgExternalDBName : "smw+" . $wiki;
 			wfDebugLog( "connect", __METHOD__ . ": smw+ cluster is active, requesting $wiki\n", true );
 		}
 	}

--- a/includes/wikia/DefaultSettings.php
+++ b/includes/wikia/DefaultSettings.php
@@ -817,6 +817,14 @@ $wgMaxCommentsToMove = 50;
 $smwgUseExternalDB = false;
 
 /**
+ * Semantic Mediawiki external cluster DB Name
+ * @name $smwgExternalDBName
+ *
+ * @see \SMW\MediaWiki\LazyDBConnectionProvider
+ */
+$smwgExternalDBName = false;
+
+/**
  * Default value for AB testing array
  */
 


### PR DESCRIPTION
## Links
* https://wikia-inc.atlassian.net/browse/PLATFORM-5091

## Description
When migrating wiki we change DB name, but we are not copying original SMW db with backup DB. We should query to the old DB, because we never drop it because we use different prefix in UCP `smwucp+`.

## Who might be intrested
@Wikia/core-platform-team 
 