### PR TITLE
IW | fix bool -> string conversion for query params

### DIFF
--- a/extensions/wikia/FeedsAndPosts/Discussion/DiscussionPermalinkController.php
+++ b/extensions/wikia/FeedsAndPosts/Discussion/DiscussionPermalinkController.php
@@ -40,7 +40,7 @@ class DiscussionPermalinkController extends WikiaController {
 		$user = $this->context->getUser();
 		$postId = $request->getVal( 'postId' );
 		$queryParams = $this->getQueryParams( $request );
-		$queryParams['canViewHidden'] = $user->isAllowed( 'threads:viewhidden' );
+		$queryParams['canViewHidden'] = $user->isAllowed( 'threads:viewhidden' ) ? 'true' : 'false';
 
 		[ 'statusCode' => $statusCode, 'body' => $body ] =
 			$this->gateway->getThreadByPostId( $postId, $user->getId(), $queryParams );


### PR DESCRIPTION
when boolean is passed to build_query_param, it is converted to either 0 or 1, while discussion service requires 'true' or 'false' strings.

@Wikia/iwing 