### PR TITLE
DE-5192 | Deploy fast performing queries to RDS

### DIFF
--- a/extensions/wikia/Hydralytics/classes/Information.php
+++ b/extensions/wikia/Hydralytics/classes/Information.php
@@ -29,7 +29,7 @@ class Information {
 	static public function getEditsLoggedInOut($days = self::LAST_DAYS) {
 		global $wgCityId;
 
-		$res = \RDS::query(
+		$res = \Redshift::query(
 			'SELECT dt, COUNT(*) AS total_edits, ' .
 			'SUM(case when user_id = 0 then 1 else 0 end) as edits_anons ' . '
 			 FROM wikianalytics.edits ' .
@@ -94,7 +94,7 @@ class Information {
 	static public function getGeolocation($limit = 10) {
 		global $wgCityId;
 
-		$res = \RDS::query(
+		$res = \Redshift::query(
 			'SELECT country, SUM(cnt) as views FROM wikianalytics.sessions ' .
 			'WHERE wiki_id = :wiki_id GROUP BY country ' .
 			'ORDER BY views DESC LIMIT :limit',

--- a/extensions/wikia/Hydralytics/classes/Information.php
+++ b/extensions/wikia/Hydralytics/classes/Information.php
@@ -170,33 +170,8 @@ class Information {
 	 */
 	static public function getDailyTotals() {
 		global $wgCityId;
-
-		$sql =
-			'SELECT generate_series AS n FROM generate_series((NOW()::DATE - INTERVAL \'' . self::LAST_DAYS . ' days\'), ((NOW() - interval  \'1 DAY\')::DATE), \'1 day\')' .
-			'),' .
-			'pages AS (' .
-			'SELECT dt, SUM(views) as views FROM wikianalytics.pageviews_by_wiki_and_date ' .
-			"WHERE wiki_id = :wiki_id " .
-			'group by dt ' .
-			') ' .
-			'SELECT n AS dt, COALESCE(views, 0) AS views ' .
-			'FROM dates ' .
-			'LEFT OUTER JOIN pages ' .
-			'ON n=dt ' .
-			'ORDER BY dt DESC';
-
-		$res = \RDS::query(
-			$sql,
-			[ ':wiki_id' => $wgCityId ]
-		);
-
-		$pageviews = [];
-		foreach ( $res as $row ) {
-			// e.g. 2019-06-28 -> 166107
-			$pageviews[$row->dt] = $row->views;
-		}
 		return [
-			'pageviews' => $pageviews
+			'pageviews' => \RDS::getDailyTotals(self::LAST_DAYS)
 		];
 	}
 

--- a/includes/wikia/RDS.class.php
+++ b/includes/wikia/RDS.class.php
@@ -109,12 +109,14 @@ class RDS {
 	public static function getDailyTotals(int $days) : array {
 		global $wgCityId;
 
-		$sql = 'WITH dates AS (' . # generates a sequence of dates between the current date and :days before
-			'SELECT generate_series AS n FROM generate_series((NOW()::DATE - INTERVAL \''. $days .' days\'), (NOW()::DATE), \'1 day\')' . # does not work well with passing the :days as a parameter, so it was added to the string
+		$sql =
+			'WITH dates AS (' . # generates a sequence of dates between the current date and :days before
+			'SELECT generate_series AS n FROM generate_series((NOW()::DATE - INTERVAL \'' . $days . ' days\'), ((NOW() - interval  \'1 DAY\')::DATE), \'1 day\')' .
 			'),' .
 			'pages AS (' .
-			'SELECT dt, views FROM wikianalytics.pageviews_by_wiki_and_date ' .
-			'WHERE wiki_id = :wiki_id ' .
+			'SELECT dt, SUM(views) as views FROM wikianalytics.pageviews_by_wiki_and_date ' .
+			"WHERE wiki_id = :wiki_id " .
+			'group by dt ' .
 			') ' .
 			'SELECT n AS dt, COALESCE(views, 0) AS views ' .
 			'FROM dates ' .

--- a/includes/wikia/RDS.class.php
+++ b/includes/wikia/RDS.class.php
@@ -111,7 +111,7 @@ class RDS {
 
 		$sql =
 			'WITH dates AS (' . # generates a sequence of dates between the current date and :days before
-			'SELECT generate_series AS n FROM generate_series((NOW()::DATE - INTERVAL \'' . $days . ' days\'), ((NOW() - interval  \'1 DAY\')::DATE), \'1 day\')' .
+			'SELECT DATE(generate_series) AS n FROM generate_series((NOW()::DATE - INTERVAL \'' . $days . ' days\'), ((NOW() - interval  \'1 DAY\')::DATE), \'1 day\')' .
 			'),' .
 			'pages AS (' .
 			'SELECT dt, SUM(views) as views FROM wikianalytics.pageviews_by_wiki_and_date ' .


### PR DESCRIPTION
## Links
* https://wikia-inc.atlassian.net/browse/DE-5192

Deploys these queries:

```
0. {'File': 'getActiveEditorsSpeedUp.sql', 'mean': 2.967857142857143, 'stdev': 0.03162503529077649, 'max': 3.0170000000000003} 

1. {'File': 'getNumberOfVisitorsRealQuery.sql', 'mean': 15.482285714285714, 'stdev': 9.679285092648211, 'max': 25.147000000000002} 


2. {'File': 'getDailyTotals.sql', 'mean': 38.714999999999996, 'stdev': 5.85910681475143, 'max': 46.39} 

3. {'File': 'getDeviceBreakdownBrowser.sql', 'mean': 61.36528571428572, 'stdev': 19.373022150353705, 'max': 87.85300000000001} 

4. {'File': 'getDeviceBreakdownDevice.sql', 'mean': 62.61271428571429, 'stdev': 21.763123770224144, 'max': 96.514} 

5. {'File': 'getTopViewedFiles.sql', 'mean': 382.77342857142855, 'stdev': 560.4601234854141, 'max': 1607.98} 

```
which perform well
