### PR TITLE
DE-5074 | Replace uses of Redshift in QuickStatsController with Redshift

### DIFF
--- a/extensions/wikia/AdminDashboard/QuickStatsController.class.php
+++ b/extensions/wikia/AdminDashboard/QuickStatsController.class.php
@@ -35,7 +35,7 @@ class QuickStatsController extends WikiaController {
 	}
 
 	protected function getDailyPageViews( Array &$stats ) {
-		$pageviews = Redshift::getDailyTotals(7);
+		$pageviews = \RDS::getDailyTotals(7);
 		$stats['totals']['pageviews'] = 0;
 		foreach( $pageviews as $date => $value) {
 			$stats[$date]['pageviews'] = $value;
@@ -48,7 +48,8 @@ class QuickStatsController extends WikiaController {
 		global $wgCityId;
 
 		$week = date( 'Y-m-d', strtotime('-7 day') );
-		$res = \Redshift::query(
+
+		$res = \RDS::query(
 			'SELECT dt, COUNT(*) AS total_edits '.
 			'FROM wikianalytics.edits ' .
 			'WHERE wiki_id = :wiki_id AND dt >= :week GROUP BY dt ' .

--- a/includes/wikia/RDS.class.php
+++ b/includes/wikia/RDS.class.php
@@ -109,12 +109,14 @@ class RDS {
 	public static function getDailyTotals(int $days) : array {
 		global $wgCityId;
 
-		$sql = 'WITH dates AS (' . # generates a sequence of dates between the current date and :days before
-			'SELECT generate_series AS n FROM generate_series((NOW()::DATE - INTERVAL \''. $days .' days\'), (NOW()::DATE), \'1 day\')' . # does not work well with passing the :days as a parameter, so it was added to the string
+		$sql =
+			'WITH dates AS (' . # generates a sequence of dates between the current date and :days before
+			'SELECT generate_series AS n FROM generate_series((NOW()::DATE - INTERVAL \'' . $days . ' days\'), ((NOW() - interval  \'1 DAY\')::DATE), \'1 day\')' .
 			'),' .
 			'pages AS (' .
-			'SELECT dt, views FROM wikianalytics.pageviews_by_wiki_and_date ' .
-			'WHERE wiki_id = :wiki_id ' .
+			'SELECT dt, SUM(views) as views FROM wikianalytics.pageviews_by_wiki_and_date ' .
+			"WHERE wiki_id = :wiki_id " .
+			'group by dt ' .
 			') ' .
 			'SELECT n AS dt, COALESCE(views, 0) AS views ' .
 			'FROM dates ' .

--- a/includes/wikia/RDS.class.php
+++ b/includes/wikia/RDS.class.php
@@ -111,7 +111,7 @@ class RDS {
 
 		$sql =
 			'WITH dates AS (' . # generates a sequence of dates between the current date and :days before
-			'SELECT generate_series AS n FROM generate_series((NOW()::DATE - INTERVAL \'' . $days . ' days\'), ((NOW() - interval  \'1 DAY\')::DATE), \'1 day\')' .
+			'SELECT DATE(generate_series) AS n FROM generate_series((NOW()::DATE - INTERVAL \'' . $days . ' days\'), ((NOW() - interval  \'1 DAY\')::DATE), \'1 day\')' .
 			'),' .
 			'pages AS (' .
 			'SELECT dt, SUM(views) as views FROM wikianalytics.pageviews_by_wiki_and_date ' .


### PR DESCRIPTION
1. {'File': 'QuickStatsgetDailyEdits.sql', 'mean': 13.376428571428573, 'stdev': 17.052223001289725, 'max': 47.315000000000005} 
2. {'File': 'getDailyTotals.sql', 'mean': 41.65728571428571, 'stdev': 30.80196346400819, 'max': 78.322} 


RDS queries used by QuickStats perform well now, so they can be moved.