### PR TITLE
DE-5200 | Switch getGeolocation to RDS and make it return pageviews as intended

### DIFF
--- a/extensions/wikia/Hydralytics/classes/Information.php
+++ b/extensions/wikia/Hydralytics/classes/Information.php
@@ -94,8 +94,8 @@ class Information {
 	static public function getGeolocation($limit = 10) {
 		global $wgCityId;
 
-		$res = \Redshift::query(
-			'SELECT country, SUM(cnt) as views FROM wikianalytics.sessions ' .
+		$res = \RDS::query(
+			'SELECT country, SUM(cnt) as views FROM wikianalytics.geolocation ' .
 			'WHERE wiki_id = :wiki_id GROUP BY country ' .
 			'ORDER BY views DESC LIMIT :limit',
 			[ ':wiki_id' => $wgCityId, ':limit' => $limit ]

--- a/extensions/wikia/Hydralytics/classes/Information.php
+++ b/extensions/wikia/Hydralytics/classes/Information.php
@@ -95,8 +95,8 @@ class Information {
 		global $wgCityId;
 
 		$res = \RDS::query(
-			'SELECT country, SUM(cnt) as views FROM wikianalytics.geolocation ' .
-			'WHERE wiki_id = :wiki_id GROUP BY country ' .
+			'SELECT country, cnt as views FROM wikianalytics.geolocation ' .
+			'WHERE wiki_id = :wiki_id ' .
 			'ORDER BY views DESC LIMIT :limit',
 			[ ':wiki_id' => $wgCityId, ':limit' => $limit ]
 		);

--- a/extensions/wikia/Hydralytics/specials/SpecialAnalytics.php
+++ b/extensions/wikia/Hydralytics/specials/SpecialAnalytics.php
@@ -145,7 +145,6 @@ class SpecialAnalytics extends \SpecialPage {
 					$geolocation = Information::getGeolocation();
 					$sections['geolocation'] = TemplateAnalytics::wrapSectionData('geolocation', $geolocation);
 					$countries = \CountryNames::getNames($wgLang->getCode());
-					//arsort($geolocation['sessions']);
 					if (isset($geolocation['pageviews'])) {
 						$sections['geolocation'] = "
 					<table class=\"analytics_table\">
@@ -157,11 +156,11 @@ class SpecialAnalytics extends \SpecialPage {
 						</thead>
 						<tbody>
 						";
-						foreach ($geolocation['pageviews'] as $location => $sessions) {
+						foreach ($geolocation['pageviews'] as $location => $pageviews) {
 							$sections['geolocation'] .= "
 							<tr>
 								<td>" . $countries[$location] . "</td>
-								<td>" . $this->getLanguage()->formatNum($sessions) . "</td>
+								<td>" . $this->getLanguage()->formatNum($pageviews) . "</td>
 							</tr>";
 						}
 						$sections['geolocation'] .= "


### PR DESCRIPTION
Switches getGeolocation table to use RDS.
This RDS solution is 4800x faster on the biggest wikis than the previous proposed RDS solution. 

Also:
Throughout the entire time WikiAnalytics was showing sessions in getGeolocation. 
However strings on the page intended pageviews. It was a cause for confusion for community.
Now it shows pageviews as intended. 
This will result in often 100x higher numbers than before this PR, so we expect questions.


**DO NOT MERGE UNTIL wikianalytics.geolocation is backfilled 1 day back!**

## Links
* https://wikia-inc.atlassian.net/browse/DE-5200

## Description

## Acceptance Criteria
- [ ] test for new code.

## Who might be interested
