### PR TITLE
IW | fix notices in MW proxy for discussion service

### DIFF
--- a/extensions/wikia/DiscussionModeration/ReportedPostsHelper.class.php
+++ b/extensions/wikia/DiscussionModeration/ReportedPostsHelper.class.php
@@ -16,6 +16,10 @@ class ReportedPostsHelper {
 	}
 
 	public function addPermissions( User $user, array &$reportedPosts ) {
+		if ( !isset( $reportedPosts['_embedded']['doc:posts'] ) ) {
+			return;
+		}
+
 		foreach ( $reportedPosts['_embedded']['doc:posts'] as &$postData ) {
 			$post = ( new PostBuilder() )
 				->position( $postData['position'] )
@@ -46,10 +50,12 @@ class ReportedPostsHelper {
 			}
 		}
 
-		foreach ( $reportedPosts['_embedded']['doc:posts'] as &$post ) {
-			if ( isset( $post['_links']['permalink'][0]['href'] ) ) {
-				$uri = new Uri( $post['_links']['permalink'][0]['href'] );
-				$post['_links']['permalink'][0]['href'] = $this->buildPermalink( $uri );
+		if ( isset( $reportedPosts['_embedded']['doc:posts'] ) ) {
+			foreach ( $reportedPosts['_embedded']['doc:posts'] as &$post ) {
+				if ( isset( $post['_links']['permalink'][0]['href'] ) ) {
+					$uri = new Uri( $post['_links']['permalink'][0]['href'] );
+					$post['_links']['permalink'][0]['href'] = $this->buildPermalink( $uri );
+				}
 			}
 		}
 	}

--- a/extensions/wikia/FeedsAndPosts/Discussion/DiscussionPermalinkController.php
+++ b/extensions/wikia/FeedsAndPosts/Discussion/DiscussionPermalinkController.php
@@ -3,9 +3,9 @@
 use GuzzleHttp\Client;
 use GuzzleHttp\Psr7\Uri;
 use Wikia\Factory\ServiceFactory;
-use Wikia\FeedsAndPosts\Discussion\PermissionsHelper;
-use Wikia\FeedsAndPosts\Discussion\LinkHelper;
 use Wikia\FeedsAndPosts\Discussion\DiscussionGateway;
+use Wikia\FeedsAndPosts\Discussion\LinkHelper;
+use Wikia\FeedsAndPosts\Discussion\PermissionsHelper;
 use Wikia\FeedsAndPosts\Discussion\QueryParamsHelper;
 
 class DiscussionPermalinkController extends WikiaController {
@@ -146,8 +146,10 @@ class DiscussionPermalinkController extends WikiaController {
 	private function addPermissions( array &$body, User $user ) {
 		$body = PermissionsHelper::applyPermissionsForPost( $body, $body, $user );
 
-		foreach ( $body['_embedded']['doc:posts'] as &$postData ) {
-			$postData = PermissionsHelper::applyPermissionsForPost( $postData, $body, $user );
+		if ( isset( $body['_embedded']['doc:posts'] ) ) {
+			foreach ( $body['_embedded']['doc:posts'] as &$postData ) {
+				$postData = PermissionsHelper::applyPermissionsForPost( $postData, $body, $user );
+			}
 		}
 
 		$body['_embedded']['firstPost'][0] = PermissionsHelper::applyPermissionsForPost(
@@ -160,11 +162,13 @@ class DiscussionPermalinkController extends WikiaController {
 	}
 
 	private function mapLinks( array &$body, IContextSource $requestContext ) {
-		foreach ( $body['_embedded']['doc:posts'] as &$post ) {
-			if ( isset( $post['_links']['permalink'][0]['href'] ) ) {
-				$uri = new Uri( $post['_links']['permalink'][0]['href'] );
-				$post['_links']['permalink'][0]['href'] =
-					$this->linkHelper->buildPermalink( $uri, $requestContext );
+		if ( isset( $body['_embedded']['doc:posts'] ) ) {
+			foreach ( $body['_embedded']['doc:posts'] as &$post ) {
+				if ( isset( $post['_links']['permalink'][0]['href'] ) ) {
+					$uri = new Uri( $post['_links']['permalink'][0]['href'] );
+					$post['_links']['permalink'][0]['href'] =
+						$this->linkHelper->buildPermalink( $uri, $requestContext );
+				}
 			}
 		}
 


### PR DESCRIPTION
In case when the request is made to permalink resource with postId pointing to the id of thread's first post, the doc:posts field is not set. Lets not throw notices in such case - it breaks opening links from notifications

Who might be interested
@Wikia/iwing