### PR TITLE
DE-5210 | Change DE team name to dataeng

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -99,8 +99,8 @@ resources/Ace/*     @Wikia/core-team
 #
 # The Data Engineering team (aka DataEng) 
 #
-includes/wikia/api/CrossWikiArticlesApiController.class.php		@Wikia/data-engineering
-includes/wikia/api/DWDimensionApiController.class.php    @Wikia/data-engineering
-includes/wikia/api/DWDimensionApiControllerSQL.class.php    @Wikia/data-engineering
-extensions/wikia/DataWarehouse/*    @Wikia/data-engineering
-extensions/wikia/Hydralytics/*    @Wikia/data-engineering
+includes/wikia/api/CrossWikiArticlesApiController.class.php		@Wikia/dataeng
+includes/wikia/api/DWDimensionApiController.class.php    @Wikia/dataeng
+includes/wikia/api/DWDimensionApiControllerSQL.class.php    @Wikia/dataeng
+extensions/wikia/DataWarehouse/*    @Wikia/dataeng
+extensions/wikia/Hydralytics/*    @Wikia/dataeng


### PR DESCRIPTION
## Links
https://wikia-inc.atlassian.net/browse/DE-4540
https://wikia-inc.atlassian.net/browse/DE-5210

## Description
data-engineering vs. dataeng inconsistency is causing problems with alerting etc.

## Who might be interested
@MikolajBalcerek