### PR TITLE
[DE wikianalytics] Remove last Redshift query

### DIFF
--- a/extensions/wikia/Hydralytics/classes/Information.php
+++ b/extensions/wikia/Hydralytics/classes/Information.php
@@ -201,7 +201,7 @@ class Information {
 		}
 
 		// by device type (filter out bots)
-		$res = \Redshift::query(
+		$res = \RDS::query(
 			'SELECT device_type, SUM(cnt) AS views FROM wikianalytics.sessions ' .
 			'WHERE wiki_id = :wiki_id AND device_type <> \'bot\' GROUP BY device_type ' .
 			'ORDER BY views DESC LIMIT :limit',


### PR DESCRIPTION
We're moving away from Redshift. All WikiAnalytics queries should go to RDS.