### PR TITLE
[DE recommendations] Remove beacon from reco request

### DIFF
--- a/extensions/wikia/Recirculation/js/helpers/recommendedContent.js
+++ b/extensions/wikia/Recirculation/js/helpers/recommendedContent.js
@@ -69,10 +69,7 @@ define('ext.wikia.recirculation.helpers.recommendedContent', [
             data: {
                 wikiId: w.wgCityId,
                 articleId: w.wgArticleId
-            },
-			headers: {
-				'X-Beacon': w.beacon_id
-			}
+            }
         }).done(function (result) {
             deferred.resolve(mapExperimentalDataResponse(result));
         }).fail(function (err) {


### PR DESCRIPTION
The beacon is unused an causes unnecessary OPTIONS requests.