### PR TITLE
Replace CC wikiID with Appcommunity ID

### DIFF
--- a/docker/maintenance/create-cronjob-yaml.sh
+++ b/docker/maintenance/create-cronjob-yaml.sh
@@ -31,7 +31,7 @@ ARGS=`echo "$JOB_JSON" | jq .args[] | sed -e 's/^/            - /g'`
 SERVER_ID=`echo "$JOB_JSON" | jq .server_id`
 
 if [ "$SERVER_ID" = 'null' ]; then
-	SERVER_ID="177"
+	SERVER_ID="2393201"
 fi
 
 if [ "$SCHEDULE" = 'null' ]; then

--- a/lib/Wikia/src/Tasks/AsyncTaskList.php
+++ b/lib/Wikia/src/Tasks/AsyncTaskList.php
@@ -23,7 +23,7 @@ use Wikia\Tasks\Queues\CategoryCountsQueue;
 
 class AsyncTaskList {
 	/** @const int default wiki city to run tasks in (community) */
-	const DEFAULT_WIKI_ID = 177;
+	const DEFAULT_WIKI_ID = 2393201;
 
 	/** which config to grab when figuring out the executor (on the job queue side) */
 	const EXECUTOR_APP_NAME = 'mediawiki';

--- a/maintenance/cohesionCheck.php
+++ b/maintenance/cohesionCheck.php
@@ -25,7 +25,7 @@ if ( !$primaryOnly ) {
 }
 
 for ($i = 0; $i < $max_tries; ++$i) {
-	$cmd = 'SERVER_ID=177 php maintenance/rebuildLocalisationCache.php --force --primary --cache-dir=/tmp/messagecache-new' . $i;
+	$cmd = 'SERVER_ID=2393201 php maintenance/rebuildLocalisationCache.php --force --primary --cache-dir=/tmp/messagecache-new' . $i;
 	shell_exec( $cmd );
 	print 'cache ' . $i . ' done' . PHP_EOL;
 }

--- a/maintenance/wikia/confirmEmail.php
+++ b/maintenance/wikia/confirmEmail.php
@@ -22,7 +22,7 @@
 
 // Eliminate the need to set this on the command line
 if ( !getenv( 'SERVER_ID' ) ) {
-	putenv( "SERVER_ID=177" );
+	putenv( "SERVER_ID=2393201" );
 }
 
 ini_set( 'display_errors', 'stderr' );

--- a/maintenance/wikia/runOnCluster.php
+++ b/maintenance/wikia/runOnCluster.php
@@ -66,7 +66,7 @@
 
 // Eliminate the need to set this on the command line
 if ( !getenv( 'SERVER_ID' ) ) {
-	putenv( "SERVER_ID=177" );
+	putenv( "SERVER_ID=2393201" );
 }
 
 ini_set( 'display_errors', 'stderr' );

--- a/metrics.php
+++ b/metrics.php
@@ -8,7 +8,7 @@
 
 // Prometheus does not set a "Host" header,
 // tell WikiFactoryLoader class which wiki to use when serving this request
-$_ENV['SERVER_ID'] = 177;
+$_ENV['SERVER_ID'] = 2393201;
 
 require __DIR__ . '/includes/WebStart.php'; // we want to load config to have $wgRedisHost
 


### PR DESCRIPTION
Soon Community central will be migrated and no longer served from App. We should switch to appcommunity wiki instead