### PR TITLE
PLATFORM-5615 | Add J cluster configuration to App VariablesExpansions.php

### DIFF
--- a/includes/wikia/VariablesExpansions.php
+++ b/includes/wikia/VariablesExpansions.php
@@ -308,6 +308,10 @@ $wgLBFactoryConf = [
             'geo-db-i-master.query.consul.' => 0,
             'geo-db-i-slave.query.consul.' => 1000,
         ],
+        'c10' => [
+            'geo-db-j-master.query.consul.' => 0,
+            'geo-db-j-slave.query.consul.' => 1000,
+        ],
 
         'ext1' => $wgDBArchiveCluster,
         'specials' => [


### PR DESCRIPTION
## Links
* https://wikia-inc.atlassian.net/browse/PLATFORM-5612

## Description
App set configuration in multiple places in `config` repo, this one was forgotten and because of that wikis from `j` cluster couldn't be closed. We probably don't need that anymore as new UCP script will take care of slot2 wikis, and there shouldn't be any wikis on slot1 from J cluster.

## Who might be interested?
@Wikia/core-platform-team 