### PR TITLE
PortableInfobox: Fix `<image>` tag margins on non‑Oasis skins

### DIFF
--- a/extensions/wikia/PortableInfobox/styles/PortableInfoboxMixins.scss
+++ b/extensions/wikia/PortableInfobox/styles/PortableInfoboxMixins.scss
@@ -29,6 +29,7 @@
 	$padding: 10px;
 
 	.pi-image {
+		margin: 0; // remove default margins added by the user agent stylesheet
 		text-align: center; // center smaller image inside infobox
 	}
 


### PR DESCRIPTION
This is done so that the <code>[&lt;image&gt;](https://community.fandom.com/wiki/Help:Infoboxes/Tags#%3Cimage%3E)</code> tag at least has the correct margins on **Gamepedia** wikis, instead of [the user agent stylesheet defaults](https://html.spec.whatwg.org/multipage/rendering.html#flow-content-3):

```css
figure {
	margin-block: 1em;
	margin-inline: 40px;
}
```

---

Needs to be ported [to the UCP repository](https://github.com/Wikia/unified-platform/tree/master/extensions/fandom/PortableInfobox).